### PR TITLE
Initialization from FVCOM Data

### DIFF
--- a/tools/utilities/CMakeLists.txt
+++ b/tools/utilities/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(refine-chkpt)
 add_subdirectory(coarsen-chkpt)
+add_subdirectory(create-chkpt)
 add_subdirectory(CheckpointToCSV)
 add_subdirectory(PlotfileToCSV)

--- a/tools/utilities/create-chkpt/CMakeLists.txt
+++ b/tools/utilities/create-chkpt/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(tool_exe_name kynema_sgf_create_chkpt)
+
+add_executable(${tool_exe_name})
+target_sources(${tool_exe_name}
+  PRIVATE
+  CreateCheckpt.cpp
+  create_chkpt.cpp)
+
+target_include_directories(${tool_exe_name} PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_link_libraries(${tool_exe_name} PRIVATE ${kynema_sgf_lib_name} AMReX-Hydro::amrex_hydro_api)
+if (KYNEMA_SGF_ENABLE_W2A)
+  target_link_libraries(${tool_exe_name} PRIVATE Waves2AMR::Waves2AMR)
+endif()
+set_cuda_build_properties(${tool_exe_name})
+
+install(TARGETS ${tool_exe_name})

--- a/tools/utilities/create-chkpt/CreateCheckpt.H
+++ b/tools/utilities/create-chkpt/CreateCheckpt.H
@@ -1,0 +1,29 @@
+#ifndef CREATECHECKPT_H
+#define CREATECHECKPT_H
+
+#include "src/incflo.H"
+
+namespace kynema_sgf {
+namespace tools {
+
+class CreateCheckpt : public incflo
+{
+public:
+    CreateCheckpt();
+
+    virtual ~CreateCheckpt() = default;
+
+    void interpolate();
+
+    void read_fvcom_data();
+
+    void run_utility();
+
+private:
+
+};
+
+} // namespace tools
+} // namespace kynema_sgf
+
+#endif /* CREATECHECKPT_H */

--- a/tools/utilities/create-chkpt/CreateCheckpt.cpp
+++ b/tools/utilities/create-chkpt/CreateCheckpt.cpp
@@ -1,0 +1,82 @@
+#include "CreateCheckpt.H"
+#include "src/utilities/IOManager.H"
+#include "src/utilities/ncutils/nc_interface.H"
+#include "netcdf.h"
+#include "netcdf_par.h"
+
+namespace kynema_sgf {
+namespace tools {
+
+CreateCheckpt::CreateCheckpt() : incflo() {}
+
+
+void CreateCheckpt::interpolate()
+{
+
+}
+
+#ifdef KYNEMA_SGF_USE_NETCDF
+void CreateCheckpt::read_fvcom_data()
+{
+    amrex::Print() << "Reading FVCOM data" << std::endl;
+
+    // Set up a parmParse to look for "Initialization" inputs.
+    amrex::ParmParse pp("Initialization");
+
+    // Get the FVCOM file name.
+    std::string m_fvcom_filename;
+    pp.query("FVCOM_filename", m_fvcom_filename);
+    amrex::Print() << "   -reading file: " << m_fvcom_filename << std::endl;
+
+    // Open the FVCOM file using netcdf utils.
+    auto ncdata = ncutils::NCFile::open(m_fvcom_filename, NC_NOWRITE);
+    amrex::Print() << "   -file opened..." << std::endl;
+
+
+    size_t n_elems = ncdata.dim("nele").len();
+    size_t n_nodes = ncdata.dim("node").len();
+    amrex::Print() << "   -number of elements: " << n_elems << std::endl;
+    amrex::Print() << "   -number of nodes:    " << n_nodes << std::endl;
+
+    auto xc = ncdata.var("xc");
+    auto yc = ncdata.var("yc");
+    auto u = ncdata.var("u");
+    auto v = ncdata.var("v");
+
+    amrex::Print() << "    -reading x, y, u, v data..." << std::endl;
+    amrex::Vector<amrex::Real> tmp(n_elems, 0.0_rt);
+    xc.get(tmp.data(), {0}, {n_elems});
+    yc.get(tmp.data(), {0}, {n_elems});
+    u.get(tmp.data(), {0}, {n_elems});
+    v.get(tmp.data(), {0}, {n_elems});
+    amrex::Print() << "   -read data..." << std::endl;
+
+
+    ncdata.close();
+}
+#endif
+
+void CreateCheckpt::run_utility()
+{
+    // Default constructor. Note inheritance: incflo : AmrCore : AmrMesh.
+    incflo my_incflo;
+
+    // Initialize data, parameters, arrays and derived internals
+    my_incflo.InitData();
+
+    // Set up a parmParse to look for "Initialization" inputs.
+    amrex::ParmParse pp("Initialization");
+    std::string m_initial_data_type;
+    pp.query("data_type", m_initial_data_type);
+
+    amrex::Print() << "data_type = " << m_initial_data_type << std::endl;
+
+    // Call the data reader.
+    if ((m_initial_data_type == "fvcom") ||
+        (m_initial_data_type == "FVCOM")) {
+        read_fvcom_data();
+    }
+}
+
+} // namespace tools
+} // namespace kynema_sgf

--- a/tools/utilities/create-chkpt/create_chkpt.cpp
+++ b/tools/utilities/create-chkpt/create_chkpt.cpp
@@ -1,0 +1,44 @@
+#include "CreateCheckpt.H"
+#include "src/incflo.H"
+#include "src/utilities/console_io.H"
+
+
+int main(int argc, char* argv[])
+{
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+#endif
+
+    using namespace amrex::mpidatatypes;
+
+    kynema_sgf::io::print_banner(MPI_COMM_WORLD, std::cout);
+
+    amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, []() {
+        amrex::ParmParse pp("amrex");
+        // Set the defaults so that we throw an exception instead of attempting
+        // to generate backtrace files. However, if the user has explicitly set
+        // these options in their input files respect those settings.
+        if (!pp.contains("throw_exception")) {
+            pp.add("throw_exception", 1);
+        }
+        if (!pp.contains("signal_handling")) {
+            pp.add("signal_handling", 0);
+        }
+    });
+
+    { /* These braces are necessary to ensure amrex::Finalize() can be called
+        without explicitly deleting all the incflo member MultiFabs */
+
+        BL_PROFILE("create-chkpt::main");
+        kynema_sgf::tools::CreateCheckpt obj;
+        obj.run_utility();
+    }
+
+    amrex::Finalize();
+
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
The executable, create-chkpt, reads the case input file, creates a mesh, reads FVCOM data, interpolates to the mesh, populates the appropriate variables, and write plt and chkpt files.  The intent is for the chkpt files to be used as initial conditions.  Eventually want to extend this to read WRF data, too.

## Summary

This is currently a work-in-progress.  I am to the point that I can read the FVCOM data, but not successful yet in extracting the variables I need.  To do:
-Extract the correct FVCOM data (I think xc, yc, h, siglay, zeta).
-Translate from UTM coordinates to local coordinates
-Interpolate from unstructured FVCOM to structured AMR-Wind points
-Load into AMR-Wind u,v,w variables


## Pull request type

Draft

Please check the type of change introduced:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

See my input file at: /projects/hfm/churchfield/rosario/test.  
Run the new code with: srun -n 1 kynema_sgf_create_chkpt rosario.inp

Look in the rosario.inp file for this new input so far:
Initialization.data_type = "FVCOM"
Initialization.FVCOM_filename = "/projects/hfm/churchfield/rosario/FVCOM/WA_puget_sound/v1.0.0/00_raw/Puget_Sound_corrected/02012015/psm_0001.nc"

When I run, I get this error:
data_type = FVCOM
Reading FVCOM data
   -reading file: /projects/hfm/churchfield/rosario/FVCOM/WA_puget_sound/v1.0.0/00_raw/Puget_Sound_corrected/02012015/psm_0001.nc
   -file opened...
   -number of elements: 1734765
   -number of nodes:    895569
    -reading x, y, u, v data...
terminate called after throwing an instance of 'std::runtime_error'
  what():  Encountered NetCDF error; aborting
srun: error: x3001c0s25b0n0: task 0: Aborted (core dumped)

That means I'm not reading the xc, yc, u, v data properly.  I do that starting at Line 46 of tools/utilities/create-chkpt/CreateCheckpt.cpp with:

    amrex::Print() << "    -reading x, y, u, v data..." << std::endl;
    amrex::Vector<amrex::Real> tmp(n_elems, 0.0_rt);
    xc.get(tmp.data(), {0}, {n_elems});
    yc.get(tmp.data(), {0}, {n_elems});
    u.get(tmp.data(), {0}, {n_elems});
    v.get(tmp.data(), {0}, {n_elems});
    amrex::Print() << "   -read data..." << std::endl;




Issue Number: None
