### PR TITLE
Flather BC

### DIFF
--- a/docs/sphinx/references/references.bib
+++ b/docs/sphinx/references/references.bib
@@ -2326,3 +2326,22 @@ year = {2020}
   year={2020},
   organization={IOP Publishing}
 }
+
+@article{flather:1976,
+  title={A tidal model of the northwest European continental shelf},
+  author={Flather, Roger A.},
+  journal={M{\'e}moires de la Soci{\'e}t{\'e} Royale des Sciences de Li{\`e}ge},
+  volume={10},
+  pages={141--164},
+  year={1976}
+}
+
+@article{carter-merrifield:2007,
+  title={Open boundary conditions for regional tidal simulations},
+  author={Carter, Glenn S. and Merrifield, Mark A.},
+  journal={Ocean Modelling},
+  volume={18},
+  number={3-4},
+  pages={194--209},
+  year={2007}
+}

--- a/docs/sphinx/references/references.bib
+++ b/docs/sphinx/references/references.bib
@@ -2343,5 +2343,17 @@ year = {2020}
   volume={18},
   number={3-4},
   pages={194--209},
-  year={2007}
+  year={2007},
+  doi={10.1016/j.ocemod.2007.04.003}
+}
+
+@article{marchesiello:2001,
+  title={Open boundary conditions for long-term integration of regional oceanic models},
+  author={Marchesiello, Patrick and McWilliams, James C. and Shchepetkin, Alexander},
+  journal={Ocean Modelling},
+  volume={3},
+  number={1-2},
+  pages={1--20},
+  year={2001},
+  doi={10.1016/S1463-5003(00)00013-5}
 }

--- a/docs/sphinx/spelling-wordlist.txt
+++ b/docs/sphinx/spelling-wordlist.txt
@@ -8,6 +8,7 @@ CTest
 Ekman
 Euler
 Exascale
+Flather
 Fortran
 FMB
 Joukowsky

--- a/docs/sphinx/theory/include/flather_boundary.rst
+++ b/docs/sphinx/theory/include/flather_boundary.rst
@@ -1,0 +1,94 @@
+.. _flather_boundary:
+
+Flather open boundary condition
+-------------------------------
+
+The Flather boundary condition is a radiation-type open boundary for free-surface
+flows. It allows surface gravity waves generated inside the domain to leave through
+a lateral boundary while still driving the flow toward an externally specified
+state. Compared to a simple extrapolation (Neumann) outflow, it avoids the spurious
+reflection of long waves back into the domain, and compared to a pure Dirichlet
+inflow, it does not over-constrain the interior solution.
+
+Kynema-SGF applies the condition in a depth-integrated form, which makes it
+well suited to the volume-of-fluid representation of the free surface described in
+:ref:`multiphase`. All quantities used by the boundary condition are column
+integrals taken along the vertical direction, so the boundary condition acts on
+the transport of the liquid phase rather than on individual cells in isolation.
+
+Depth-integrated quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For a given column of cells normal to a lateral boundary, the liquid height and the
+depth-integrated normal velocity (a volumetric flux per unit width) are
+
+.. math::
+
+   h = \sum_k \alpha_k\, \Delta z, \qquad
+   (uh) = \sum_k u_k\, \alpha_k\, \Delta z,
+
+where :math:`\alpha_k` is the volume fraction of liquid and :math:`u_k` is the
+boundary-normal velocity component in cell :math:`k`. Because the volume fraction
+appears as a weight, cells that contain only gas make no contribution. These sums
+are accumulated across all levels of the AMR hierarchy so that the resulting
+profiles are independent of the grid decomposition and of the local refinement.
+
+Two interior column integrals are accumulated separately: :math:`(uh)^{\rm int}_{\rm liq}`
+over cells that are entirely liquid, and :math:`(uh)^{\rm int}_{\rm mix}` over
+interfacial cells that contain both phases. The corresponding integral in the
+boundary (ghost) cells, :math:`(uh)^{\rm ext}`, represents the externally
+prescribed state, and :math:`h^{\rm ext}` is its liquid height.
+
+Boundary formulation
+~~~~~~~~~~~~~~~~~~~~
+
+The target depth-integrated flux at the boundary is
+
+.. math::
+
+   (uh)^{\rm target} = (uh)^{\rm ext} \pm c \left( h^{\rm int} - h^{\rm ext} \right),
+   \qquad c = \sqrt{g\, h^{\rm int}},
+
+where :math:`c` is the shallow-water wave speed, :math:`g` is the magnitude of the
+vertical component of :input_param:`incflo.gravity`, and the sign is negative on a
+low-side boundary and positive on a high-side boundary. The difference in liquid
+height between the interior and the boundary is what radiates the outgoing wave.
+
+Rather than imposing a uniform velocity, the interior velocity profile is rescaled
+so that its depth integral matches the target. Only fully liquid cells are
+rescaled; interfacial cells are left unchanged, because scaling interfacial cells
+have the undesirable consequence of accelerating the gas phase. The scaling factor is
+
+.. math::
+
+   f = \frac{(uh)^{\rm target} - (uh)^{\rm int}_{\rm mix}}
+                 {(uh)^{\rm int}_{\rm liq}}.
+
+The interior velocity is also clipped so that it never drives inflow at an
+outflow boundary, which keeps the applied profile consistent with the column
+integrals used to construct it.
+
+Limiting and edge cases
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The scaling above is undefined or poorly conditioned in several situations, so the
+implementation falls back to the externally prescribed profile or to a plain
+outflow condition in the following cases.
+
+* If the interior column contains no fully liquid cells, there is nothing to
+  rescale, and the externally specified profile is used instead.
+* If :math:`f` falls outside the range set by
+  :input_param:`Flather.min_velocity_scale_factor` and
+  :input_param:`Flather.max_velocity_scale_factor`, the externally specified
+  profile is used instead. This limit is most relevant during startup, when the
+  interior and exterior states can differ substantially and an unbounded scaling
+  would produce rapid, unphysical acceleration.
+* If the depth-integrated boundary velocity is essentially zero, the scaling based
+  on external quantities is undefined, and the interior profile is retained.
+* If the boundary column contains no liquid, the computed wave speed and target
+  flux are unreliable, and a standard extrapolation outflow is applied.
+
+Finally, when the depth-integrated boundary flux indicates inflow, the externally
+prescribed profile is used. Inflow is assessed from the column integral rather than
+from individual cells, so a single cell does not switch the character of the
+boundary.

--- a/docs/sphinx/theory/include/flather_boundary.rst
+++ b/docs/sphinx/theory/include/flather_boundary.rst
@@ -3,12 +3,15 @@
 Flather open boundary condition
 -------------------------------
 
-The Flather boundary condition is a radiation-type open boundary for free-surface
+The Flather boundary condition :cite:p:`flather:1976` is a radiation-type
+open boundary for free-surface
 flows. It allows surface gravity waves generated inside the domain to leave through
 a lateral boundary while still driving the flow toward an externally specified
 state. Compared to a simple extrapolation (Neumann) outflow, it avoids the spurious
 reflection of long waves back into the domain, and compared to a pure Dirichlet
-inflow, it does not over-constrain the interior solution.
+inflow, it does not over-constrain the interior solution. Comparisons of open
+boundary conditions for regional tidal simulations have found this formulation to
+be among the better performing choices :cite:p:`carter-merrifield:2007`.
 
 Kynema-SGF applies the condition in a depth-integrated form, which makes it
 well suited to the volume-of-fluid representation of the free surface described in

--- a/docs/sphinx/theory/include/flather_boundary.rst
+++ b/docs/sphinx/theory/include/flather_boundary.rst
@@ -13,11 +13,17 @@ inflow, it does not over-constrain the interior solution. Comparisons of open
 boundary conditions for regional tidal simulations have found this formulation to
 be among the better performing choices :cite:p:`carter-merrifield:2007`.
 
-Kynema-SGF applies the condition in a depth-integrated form, which makes it
+Kynema-SGF uses the condition in a depth-integrated form, which makes it
 well suited to the volume-of-fluid representation of the free surface described in
 :ref:`multiphase`. All quantities used by the boundary condition are column
-integrals taken along the vertical direction, so the boundary condition acts on
-the transport of the liquid phase rather than on individual cells in isolation.
+integrals taken along the vertical direction, so the boundary condition considers
+the transport of the liquid phase rather than focusing on individual cells in isolation.
+Though the Flather condition is formulated in two dimensions, it must be applied in the
+three-dimensional domain of Kynema-SGF, which involves scaling the local velocity 
+with depth-integrated quantities, enabling the preservation of the vertical velocity profile.
+This is established practice for regional oceanic models, in which the
+Flather condition is applied to the depth-integrated mode while the vertical
+structure of the flow is treated separately :cite:p:`marchesiello:2001`.
 
 Depth-integrated quantities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/theory/include/flather_boundary.rst
+++ b/docs/sphinx/theory/include/flather_boundary.rst
@@ -91,7 +91,7 @@ outflow condition in the following cases.
   :input_param:`Flather.max_velocity_scale_factor`, the externally specified
   profile is used instead. This limit is most relevant during startup, when the
   interior and exterior states can differ substantially and an unbounded scaling
-  would produce rapid, unphysical acceleration.
+  would produce rapid, nonphysical acceleration.
 * If the depth-integrated boundary velocity is essentially zero, the scaling based
   on external quantities is undefined, and the interior profile is retained.
 * If the boundary column contains no liquid, the computed wave speed and target

--- a/docs/sphinx/theory/theory.rst
+++ b/docs/sphinx/theory/theory.rst
@@ -9,6 +9,8 @@ Theory Manual
 
 .. include:: include/multiphase.rst
 
+.. include:: include/flather_boundary.rst
+
 .. include:: include/source_terms.rst
 
 .. include:: include/turbulence.rst

--- a/docs/sphinx/user/inputs_field_boundaries.rst
+++ b/docs/sphinx/user/inputs_field_boundaries.rst
@@ -94,6 +94,56 @@ but instead allows the user to specify variable names.
    the specified phase is present. As a result, the vof variable must be present for this capability, which 
    means the MultiPhase physics class must be active.
 
+**Flather**
+
+This type of field boundary applies a Flather (radiation-type) open boundary
+condition for velocity at lateral boundaries of free-surface flows. It permits
+surface gravity waves generated within the domain to exit through the boundary
+while still driving the flow toward an externally specified state, which reduces
+the spurious wave reflection that occurs with a simple extrapolation outflow.
+
+This field boundary requires the vof field, and therefore the
+:ref:`MultiPhase <inputs_multiphase>` physics class must be active. It applies to
+boundaries designated as ``mass_inflow`` or ``mass_inflow_outflow`` and is intended
+for the lateral (x and y) boundaries of the domain. The externally specified state
+in the boundary cells is expected to be supplied by another field boundary, such as
+OceanWavesBoundary or BoundaryPlane, or by the
+boundary condition values in the input file; the Flather boundary then modifies the
+velocity based on that state.
+
+The condition is formulated in terms of depth-integrated quantities, so the liquid
+height and the depth-integrated normal velocity are accumulated along each column
+of cells at the boundary. These sums are gathered across all levels of the mesh
+hierarchy, making the result independent of the grid decomposition and of local
+refinement. Rather than imposing a uniform velocity, the interior velocity profile
+is rescaled so that its depth integral matches the target flux, and only fully
+liquid cells are rescaled. When terrain is present, the velocity is set to zero in
+blanked cells and those cells are excluded from the column integrals. The boundary
+condition is applied to both the cell-centered velocity and the face-centered (MAC)
+velocities. For the mathematical formulation and the treatment of edge cases, see
+:ref:`the Flather boundary condition theory documentation <flather_boundary>`.
+
+The magnitude of the vertical component of :input_param:`incflo.gravity` is used as
+the gravitational constant when computing the wave speed.
+
+.. input_param:: Flather.max_velocity_scale_factor
+
+   **type:** Real, optional, default = 2.0
+
+   Upper bound on the factor used to rescale the interior velocity profile. If the
+   computed scaling factor exceeds this value, the externally specified profile is
+   used instead of the rescaled interior profile. This limit prevents overly
+   aggressive acceleration of the flow, which is most likely to occur during
+   startup or when the interior and exterior states differ substantially.
+
+.. input_param:: Flather.min_velocity_scale_factor
+
+   **type:** Real, optional, default = 0.25
+
+   Lower bound on the factor used to rescale the interior velocity profile. If the
+   computed scaling factor falls below this value, the externally specified profile
+   is used instead of the rescaled interior profile.
+
 **ModulatedPowerLaw**
 
 This type of field boundary applies a modulated power law profile for velocity

--- a/docs/sphinx/user/inputs_incflo.rst
+++ b/docs/sphinx/user/inputs_incflo.rst
@@ -25,8 +25,9 @@ as initial conditions and discretization options.
 
    Specify a string or a list of strings for each type of field boundary to initialize and use during a simulation.
    Though more than one can be specified, typically only a single field boundary type is used at a time.
-   Currently, there are three implemented field boundary types: BoundaryPlane, ModulatedPowerLaw, and OceanWavesBoundary.
-   OceanWavesBoundary relies on OceanWaves physics, but the other field boundaries can be used independently of particular
+   Currently, there are four implemented field boundary types: BoundaryPlane, Flather, ModulatedPowerLaw, and OceanWavesBoundary.
+   OceanWavesBoundary relies on OceanWaves physics, and Flather relies on MultiPhase physics, but the other field boundaries can be
+   used independently of particular
    physics classes. Refer to the :ref:`Field Boundaries documentation <inputs_field_boundaries>` for more details on each field boundary type. 
    
 .. input_param:: incflo.density

--- a/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
+++ b/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
@@ -499,7 +499,7 @@ void BoundaryPlane::initialize_data()
         if (m_repo.field_exists(fname)) {
             auto& fld = m_repo.get_field(fname);
             if (m_io_mode == io_mode::input) {
-                fld.register_fill_patch_op<PlaneFillInflow>(
+                fld.add_fill_patch_op<PlaneFillInflow>(
                     m_mesh, m_time, *this);
             }
             m_fields.emplace_back(&fld);

--- a/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
+++ b/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
@@ -499,8 +499,7 @@ void BoundaryPlane::initialize_data()
         if (m_repo.field_exists(fname)) {
             auto& fld = m_repo.get_field(fname);
             if (m_io_mode == io_mode::input) {
-                fld.add_fill_patch_op<PlaneFillInflow>(
-                    m_mesh, m_time, *this);
+                fld.add_fill_patch_op<PlaneFillInflow>(m_mesh, m_time, *this);
             }
             m_fields.emplace_back(&fld);
         } else {

--- a/src/boundary_conditions/field_boundary_fill/CMakeLists.txt
+++ b/src/boundary_conditions/field_boundary_fill/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(${kynema_sgf_lib_name}
   OceanWavesBoundary.cpp
   PlaneFillInflow.cpp
   BoundaryPlane.cpp
+  FillFlather.cpp
+  Flather.cpp
   FillMPL.cpp
   ModulatedPowerLaw.cpp
   )

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.H
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.H
@@ -15,7 +15,7 @@ public:
         Field& field,
         const amrex::AmrCore& mesh,
         const SimTime& time,
-        const Flather& flather);
+        Flather& flather);
 
     ~FillFlather() override;
 
@@ -52,7 +52,7 @@ public:
         FieldState fstate = FieldState::New) override;
 
 protected:
-    const Flather& m_flather;
+    Flather& m_flather;
 };
 
 } // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.H
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.H
@@ -1,0 +1,60 @@
+#ifndef FILLFLATHER_H
+#define FILLFLATHER_H
+
+#include "src/core/FieldFillPatchOps.H"
+#include "src/core/FieldBCOps.H"
+#include "src/boundary_conditions/field_boundary_fill/Flather.H"
+
+namespace kynema_sgf {
+
+/** Fill patch operator that applies Flather boundary updates. */
+class FillFlather : public FieldFillPatchOps<FieldBCDirichlet>
+{
+public:
+    FillFlather(
+        Field& field,
+        const amrex::AmrCore& mesh,
+        const SimTime& time,
+        const Flather& flather);
+
+    ~FillFlather() override;
+
+    void fillpatch(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        FieldState fstate = FieldState::New) override;
+
+    void fillpatch_sibling_fields(
+        int lev,
+        amrex::Real time,
+        amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& mfabs,
+        amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& ffabs,
+        amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& cfabs,
+        const amrex::IntVect& nghost,
+        const amrex::Vector<amrex::BCRec>& bcrec,
+        const amrex::Vector<amrex::BCRec>& /* unused */,
+        FieldState fstate = FieldState::New) override;
+
+    void fillpatch_from_coarse(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        FieldState fstate = FieldState::New) override;
+
+    void fillphysbc(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        FieldState fstate = FieldState::New) override;
+
+protected:
+    const Flather& m_flather;
+};
+
+} // namespace kynema_sgf
+
+#endif /* FILLFLATHER_H */

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.H
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.H
@@ -26,6 +26,14 @@ public:
         const amrex::IntVect& nghost,
         FieldState fstate = FieldState::New) override;
 
+    void fillpatch_from_coarse(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        FieldState fstate = FieldState::New) override
+    {}
+
     void fillpatch_sibling_fields(
         int lev,
         amrex::Real time,

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.H
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.H
@@ -37,13 +37,6 @@ public:
         const amrex::Vector<amrex::BCRec>& /* unused */,
         FieldState fstate = FieldState::New) override;
 
-    void fillpatch_from_coarse(
-        int lev,
-        amrex::Real time,
-        amrex::MultiFab& mfab,
-        const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) override;
-
     void fillphysbc(
         int lev,
         amrex::Real time,

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.H
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.H
@@ -27,11 +27,11 @@ public:
         FieldState fstate = FieldState::New) override;
 
     void fillpatch_from_coarse(
-        int lev,
-        amrex::Real time,
-        amrex::MultiFab& mfab,
-        const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) override
+        int /* lev */,
+        amrex::Real /* time */,
+        amrex::MultiFab& /* mfab */,
+        const amrex::IntVect& /* nghost */,
+        FieldState /* fstate */) override
     {}
 
     void fillpatch_sibling_fields(

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -63,10 +63,8 @@ void FillFlather::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
-    if (m_field.base_name() == "velocity") {
-        for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
-            m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
-        }
+    for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
+        m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }
 }
 

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -59,10 +59,10 @@ void FillFlather::fillpatch_sibling_fields(
     const int lev,
     const amrex::Real time,
     amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& mfabs,
-    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& ffabs,
-    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& cfabs,
-    const amrex::IntVect& nghost,
-    const amrex::Vector<amrex::BCRec>& bcrec,
+    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& /* ffabs */,
+    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& /* cfabs */,
+    const amrex::IntVect& /* nghost */,
+    const amrex::Vector<amrex::BCRec>& /* bcrec */,
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -23,9 +23,6 @@ void FillFlather::fillpatch(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
@@ -38,9 +35,6 @@ void FillFlather::fillpatch_from_coarse(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_from_coarse(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
@@ -53,9 +47,6 @@ void FillFlather::fillphysbc(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
@@ -72,42 +63,10 @@ void FillFlather::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
-    if (m_field.base_name() != "velocity") {
-        return;
-    }
-
-    // First foextrap MAC velocities so Flather can overwrite only boundary
-    // regions of interest.
-    amrex::Vector<amrex::BCRec> lbcrec(m_field.num_comp());
-    const auto& ibctype = m_field.bc_type();
-    for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
-        auto ori = oit();
-        const auto side = ori.faceDir();
-        const auto bct = ibctype[ori];
-        const int dir = ori.coordDir();
-        for (int i = 0; i < m_field.num_comp(); ++i) {
-            if ((bct == BC::mass_inflow) ||
-                (bct == BC::mass_inflow_outflow)) {
-                if (side == amrex::Orientation::low) {
-                    lbcrec[i].setLo(dir, amrex::BCType::foextrap);
-                } else {
-                    lbcrec[i].setHi(dir, amrex::BCType::foextrap);
-                }
-            } else {
-                if (side == amrex::Orientation::low) {
-                    lbcrec[i].setLo(dir, bcrec[i].lo(dir));
-                } else {
-                    lbcrec[i].setHi(dir, bcrec[i].hi(dir));
-                }
-            }
+    if (m_field.base_name() == "velocity") {
+        for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
+            m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
         }
-    }
-
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_sibling_fields(
-        lev, time, mfabs, ffabs, cfabs, nghost, lbcrec, lbcrec, fstate);
-
-    for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
-        m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }
 }
 

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -66,7 +66,7 @@ void FillFlather::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
-    m_flather.update_flather_variables(lev, fstate);
+    m_flather.update_flather_variables(lev, fstate, true);
     for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
         m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -24,7 +24,7 @@ void FillFlather::fillpatch(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
-        m_flather.update_flather_variables(lev);
+        m_flather.update_flather_variables(lev, fstate);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -37,7 +37,7 @@ void FillFlather::fillpatch_from_coarse(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
-        m_flather.update_flather_variables(lev);
+        m_flather.update_flather_variables(lev, fstate);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -50,7 +50,7 @@ void FillFlather::fillphysbc(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
-        m_flather.update_flather_variables(lev);
+        m_flather.update_flather_variables(lev, fstate);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -66,7 +66,7 @@ void FillFlather::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
-    m_flather.update_flather_variables(lev);
+    m_flather.update_flather_variables(lev, fstate);
     for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
         m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -20,7 +20,7 @@ void FillFlather::fillpatch(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
+    const amrex::IntVect& /* nghost */,
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
@@ -33,7 +33,7 @@ void FillFlather::fillpatch_from_coarse(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
+    const amrex::IntVect& /* nghost */,
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
@@ -46,7 +46,7 @@ void FillFlather::fillphysbc(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
+    const amrex::IntVect& /* nghost */,
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -8,7 +8,7 @@ FillFlather::FillFlather(
     Field& field,
     const amrex::AmrCore& mesh,
     const SimTime& time,
-    const Flather& flather)
+    Flather& flather)
     : FieldFillPatchOps<FieldBCDirichlet>(
           field, mesh, time, FieldInterpolator::CellConsLinear)
     , m_flather(flather)
@@ -24,6 +24,7 @@ void FillFlather::fillpatch(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
+        m_flather.update_flather_variables(lev);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -36,6 +37,7 @@ void FillFlather::fillpatch_from_coarse(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
+        m_flather.update_flather_variables(lev);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -48,6 +50,7 @@ void FillFlather::fillphysbc(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
+        m_flather.update_flather_variables(lev);
         m_flather.set_velocity(lev, time, m_field, mfab);
     }
 }
@@ -63,6 +66,7 @@ void FillFlather::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
+    m_flather.update_flather_variables(lev);
     for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
         m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -1,0 +1,114 @@
+#include <utility>
+
+#include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
+
+namespace kynema_sgf {
+
+FillFlather::FillFlather(
+    Field& field,
+    const amrex::AmrCore& mesh,
+    const SimTime& time,
+    const Flather& flather)
+    : FieldFillPatchOps<FieldBCDirichlet>(
+          field, mesh, time, FieldInterpolator::CellConsLinear)
+    , m_flather(flather)
+{}
+
+FillFlather::~FillFlather() = default;
+
+void FillFlather::fillpatch(
+    const int lev,
+    const amrex::Real time,
+    amrex::MultiFab& mfab,
+    const amrex::IntVect& nghost,
+    const FieldState fstate)
+{
+    FieldFillPatchOps<FieldBCDirichlet>::fillpatch(
+        lev, time, mfab, nghost, fstate);
+
+    if (m_field.base_name() == "velocity") {
+        m_flather.set_velocity(lev, time, m_field, mfab);
+    }
+}
+
+void FillFlather::fillpatch_from_coarse(
+    const int lev,
+    const amrex::Real time,
+    amrex::MultiFab& mfab,
+    const amrex::IntVect& nghost,
+    const FieldState fstate)
+{
+    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_from_coarse(
+        lev, time, mfab, nghost, fstate);
+
+    if (m_field.base_name() == "velocity") {
+        m_flather.set_velocity(lev, time, m_field, mfab);
+    }
+}
+
+void FillFlather::fillphysbc(
+    const int lev,
+    const amrex::Real time,
+    amrex::MultiFab& mfab,
+    const amrex::IntVect& nghost,
+    const FieldState fstate)
+{
+    FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
+        lev, time, mfab, nghost, fstate);
+
+    if (m_field.base_name() == "velocity") {
+        m_flather.set_velocity(lev, time, m_field, mfab);
+    }
+}
+
+void FillFlather::fillpatch_sibling_fields(
+    const int lev,
+    const amrex::Real time,
+    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& mfabs,
+    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& ffabs,
+    amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM>& cfabs,
+    const amrex::IntVect& nghost,
+    const amrex::Vector<amrex::BCRec>& bcrec,
+    const amrex::Vector<amrex::BCRec>& /* unused */,
+    const FieldState fstate)
+{
+    if (m_field.base_name() != "velocity") {
+        return;
+    }
+
+    // First foextrap MAC velocities so Flather can overwrite only boundary
+    // regions of interest.
+    amrex::Vector<amrex::BCRec> lbcrec(m_field.num_comp());
+    const auto& ibctype = m_field.bc_type();
+    for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
+        auto ori = oit();
+        const auto side = ori.faceDir();
+        const auto bct = ibctype[ori];
+        const int dir = ori.coordDir();
+        for (int i = 0; i < m_field.num_comp(); ++i) {
+            if ((bct == BC::mass_inflow) ||
+                (bct == BC::mass_inflow_outflow)) {
+                if (side == amrex::Orientation::low) {
+                    lbcrec[i].setLo(dir, amrex::BCType::foextrap);
+                } else {
+                    lbcrec[i].setHi(dir, amrex::BCType::foextrap);
+                }
+            } else {
+                if (side == amrex::Orientation::low) {
+                    lbcrec[i].setLo(dir, bcrec[i].lo(dir));
+                } else {
+                    lbcrec[i].setHi(dir, bcrec[i].hi(dir));
+                }
+            }
+        }
+    }
+
+    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_sibling_fields(
+        lev, time, mfabs, ffabs, cfabs, nghost, lbcrec, lbcrec, fstate);
+
+    for (int i = 0; std::cmp_less(i, mfabs.size()); ++i) {
+        m_flather.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
+    }
+}
+
+} // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillFlather.cpp
@@ -29,19 +29,6 @@ void FillFlather::fillpatch(
     }
 }
 
-void FillFlather::fillpatch_from_coarse(
-    const int lev,
-    const amrex::Real time,
-    amrex::MultiFab& mfab,
-    const amrex::IntVect& /* nghost */,
-    const FieldState fstate)
-{
-    if (m_field.base_name() == "velocity") {
-        m_flather.update_flather_variables(lev, fstate);
-        m_flather.set_velocity(lev, time, m_field, mfab);
-    }
-}
-
 void FillFlather::fillphysbc(
     const int lev,
     const amrex::Real time,

--- a/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
@@ -20,8 +20,8 @@ void FillMPL::fillpatch(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);
@@ -34,8 +34,8 @@ void FillMPL::fillpatch_from_coarse(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);
@@ -48,8 +48,8 @@ void FillMPL::fillphysbc(
     const int lev,
     const amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);

--- a/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
@@ -23,9 +23,6 @@ void FillMPL::fillpatch(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "temperature") {
@@ -40,9 +37,6 @@ void FillMPL::fillpatch_from_coarse(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_from_coarse(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "temperature") {
@@ -57,9 +51,6 @@ void FillMPL::fillphysbc(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_abl_mpl.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "temperature") {
@@ -79,35 +70,6 @@ void FillMPL::fillpatch_sibling_fields(
     const FieldState fstate)
 {
     if (m_field.base_name() == "velocity") {
-        // For an ABL MPL, we first just foextrap the mac velocities
-        amrex::Vector<amrex::BCRec> lbcrec(m_field.num_comp());
-        const auto& ibctype = m_field.bc_type();
-        for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
-            auto ori = oit();
-            const auto side = ori.faceDir();
-            const auto bct = ibctype[ori];
-            const int dir = ori.coordDir();
-            for (int i = 0; i < m_field.num_comp(); ++i) {
-                if ((bct == BC::mass_inflow) ||
-                    (bct == BC::mass_inflow_outflow)) {
-                    if (side == amrex::Orientation::low) {
-                        lbcrec[i].setLo(dir, amrex::BCType::foextrap);
-                    } else {
-                        lbcrec[i].setHi(dir, amrex::BCType::foextrap);
-                    }
-                } else {
-                    if (side == amrex::Orientation::low) {
-                        lbcrec[i].setLo(dir, bcrec[i].lo(dir));
-                    } else {
-                        lbcrec[i].setHi(dir, bcrec[i].hi(dir));
-                    }
-                }
-            }
-        }
-
-        FieldFillPatchOps<FieldBCDirichlet>::fillpatch_sibling_fields(
-            lev, time, mfabs, ffabs, cfabs, nghost, lbcrec, lbcrec, fstate);
-
         for (int i = 0; std::cmp_less(i, mfabs.size()); i++) {
             m_abl_mpl.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
         }

--- a/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
+++ b/src/boundary_conditions/field_boundary_fill/FillMPL.cpp
@@ -69,10 +69,36 @@ void FillMPL::fillpatch_sibling_fields(
     const amrex::Vector<amrex::BCRec>& /* unused */,
     const FieldState fstate)
 {
-    if (m_field.base_name() == "velocity") {
-        for (int i = 0; std::cmp_less(i, mfabs.size()); i++) {
-            m_abl_mpl.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
+    // For an ABL MPL, we first just foextrap the mac velocities
+    amrex::Vector<amrex::BCRec> lbcrec(m_field.num_comp());
+    const auto& ibctype = m_field.bc_type();
+    for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
+        auto ori = oit();
+        const auto side = ori.faceDir();
+        const auto bct = ibctype[ori];
+        const int dir = ori.coordDir();
+        for (int i = 0; i < m_field.num_comp(); ++i) {
+            if ((bct == BC::mass_inflow) || (bct == BC::mass_inflow_outflow)) {
+                if (side == amrex::Orientation::low) {
+                    lbcrec[i].setLo(dir, amrex::BCType::foextrap);
+                } else {
+                    lbcrec[i].setHi(dir, amrex::BCType::foextrap);
+                }
+            } else {
+                if (side == amrex::Orientation::low) {
+                    lbcrec[i].setLo(dir, bcrec[i].lo(dir));
+                } else {
+                    lbcrec[i].setHi(dir, bcrec[i].hi(dir));
+                }
+            }
         }
+    }
+
+    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_sibling_fields(
+        lev, time, mfabs, ffabs, cfabs, nghost, lbcrec, lbcrec, fstate);
+
+    for (int i = 0; std::cmp_less(i, mfabs.size()); i++) {
+        m_abl_mpl.set_velocity(lev, time, m_field, *mfabs[i], 0, i);
     }
 }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -40,7 +40,10 @@ public:
         int dcomp = 0,
         int orig_comp = 0) const override;
 
-    void update_flather_variables(int lev) { compute_boundary_z_averages(lev); }
+    void update_flather_variables(const int lev, const FieldState fstate)
+    {
+        compute_boundary_z_averages(lev, fstate);
+    }
 
     void accumulate_boundary(
         int current_level,
@@ -48,11 +51,12 @@ public:
         bool is_low,
         MultiLevelVector& out_uvec,
         MultiLevelVector& out_hvec,
-        bool sample_boundary) const;
+        bool sample_boundary,
+        FieldState fstate) const;
 
 private:
     void compute_internal_z_averages();
-    void compute_boundary_z_averages(int lev);
+    void compute_boundary_z_averages(int lev, FieldState fstate);
 
     const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -48,8 +48,7 @@ private:
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
     Field& m_velocity;
-    const Field* m_vof{nullptr};
-    bool m_vof_exists{false};
+    const Field& m_vof;
 
     MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -74,8 +74,8 @@ private:
     const Field& m_vof;
     const IntField* m_terrain_blank{nullptr};
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};
-    amrex::Real m_rho1{1000.0_rt};
-    amrex::Real m_rho2{1.0_rt};
+    amrex::Real m_velocity_scale_factor_max{2.0_rt};
+    amrex::Real m_velocity_scale_factor_min{0.25_rt};
 
     MultiLevelVector m_xlo_uliq{FieldLoc::CELL};
     MultiLevelVector m_xhi_uliq{FieldLoc::CELL};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -40,6 +40,14 @@ public:
         int dcomp = 0,
         int orig_comp = 0) const override;
 
+    void accumulate_boundary(
+        int lev,
+        int idir,
+        bool is_low,
+        MultiLevelVector& out_uvec,
+        MultiLevelVector& out_hvec,
+        bool sample_boundary) const;
+
 private:
     void update_target_velocity();
     void compute_boundary_z_averages();

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -76,6 +76,8 @@ private:
     const Field& m_vof;
     const IntField* m_terrain_blank{nullptr};
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};
+    amrex::Real m_rho1{1000.0_rt};
+    amrex::Real m_rho2{1.0_rt};
 
     MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -56,6 +56,10 @@ private:
     MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_ylo_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_yhi_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_bnd_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xhi_bnd_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_ylo_bnd_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_yhi_bnd_uvof_avg{FieldLoc::CELL};
     amrex::Real m_liquid_vof_eps{1.0e-12_rt};
 
     amrex::Real m_relaxation{0.5_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -54,6 +54,7 @@ public:
     void accumulate_boundary(
         int current_level,
         int idir,
+        int phase_switch,
         bool is_low,
         MultiLevelVector& out_uvec,
         MultiLevelVector& out_hvec,
@@ -79,14 +80,18 @@ private:
     amrex::Real m_rho1{1000.0_rt};
     amrex::Real m_rho2{1.0_rt};
 
-    MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_ylo_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_yhi_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_xlo_bnd_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_xhi_bnd_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_ylo_bnd_uvof_avg{FieldLoc::CELL};
-    MultiLevelVector m_yhi_bnd_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_uliq{FieldLoc::CELL};
+    MultiLevelVector m_xhi_uliq{FieldLoc::CELL};
+    MultiLevelVector m_ylo_uliq{FieldLoc::CELL};
+    MultiLevelVector m_yhi_uliq{FieldLoc::CELL};
+    MultiLevelVector m_xlo_umix{FieldLoc::CELL};
+    MultiLevelVector m_xhi_umix{FieldLoc::CELL};
+    MultiLevelVector m_ylo_umix{FieldLoc::CELL};
+    MultiLevelVector m_yhi_umix{FieldLoc::CELL};
+    MultiLevelVector m_xlo_bnd_uvof{FieldLoc::CELL};
+    MultiLevelVector m_xhi_bnd_uvof{FieldLoc::CELL};
+    MultiLevelVector m_ylo_bnd_uvof{FieldLoc::CELL};
+    MultiLevelVector m_yhi_bnd_uvof{FieldLoc::CELL};
     MultiLevelVector m_xlo_h_avg{FieldLoc::CELL};
     MultiLevelVector m_xhi_h_avg{FieldLoc::CELL};
     MultiLevelVector m_ylo_h_avg{FieldLoc::CELL};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -2,6 +2,7 @@
 #define FLATHER_H
 
 #include "src/core/Field.H"
+#include "src/core/IntField.H"
 #include "src/CFDSim.H"
 #include "src/boundary_conditions/field_boundary_fill/FieldBoundary.H"
 #include "src/utilities/MultiLevelVector.H"
@@ -49,6 +50,7 @@ private:
     const amrex::AmrCore& m_mesh;
     Field& m_velocity;
     const Field& m_vof;
+    const IntField* m_terrain_blank{nullptr};
 
     MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -1,0 +1,64 @@
+#ifndef FLATHER_H
+#define FLATHER_H
+
+#include "src/core/Field.H"
+#include "src/CFDSim.H"
+#include "src/boundary_conditions/field_boundary_fill/FieldBoundary.H"
+#include "src/utilities/trig_ops.H"
+#include "AMReX_REAL.H"
+#include <limits>
+
+using namespace amrex::literals;
+
+namespace kynema_sgf {
+
+/** Flather-style open boundary for velocity
+ *
+ *  This boundary reads current boundary ghost-cell values and adjacent interior
+ *  values, computes a blended target, and writes updated boundary values.
+ */
+class Flather : public FieldBoundary::Register<Flather>
+{
+public:
+    static std::string identifier() { return "Flather"; }
+
+    explicit Flather(CFDSim& sim);
+
+    void post_init_actions() override;
+
+    void pre_advance_work() override;
+
+    void post_advance_work() override {}
+
+    void set_velocity(
+        int lev,
+        amrex::Real time,
+        const Field& fld,
+        amrex::MultiFab& mfab,
+        int dcomp = 0,
+        int orig_comp = 0) const override;
+
+private:
+    void update_target_velocity();
+
+    const CFDSim& m_sim;
+    const kynema_sgf::SimTime& m_time;
+    const FieldRepo& m_repo;
+    const amrex::AmrCore& m_mesh;
+    Field& m_velocity;
+
+    amrex::Real m_relaxation{0.5_rt};
+    amrex::Real m_target_weight{0.5_rt};
+
+    amrex::Real m_wind_speed{8.0_rt};
+    amrex::Real m_wind_direction{270.0_rt};
+    amrex::Vector<amrex::Real> m_uvec{8.0_rt, 0.0_rt, 0.0_rt};
+
+    amrex::Real m_start_time{0.0_rt};
+    amrex::Real m_stop_time{std::numeric_limits<amrex::Real>::max()};
+    amrex::Real m_degrees_per_sec{0.0_rt};
+};
+
+} // namespace kynema_sgf
+
+#endif /* FLATHER_H */

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -60,6 +60,14 @@ private:
     MultiLevelVector m_xhi_bnd_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_ylo_bnd_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_yhi_bnd_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_xhi_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_ylo_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_yhi_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_bnd_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_xhi_bnd_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_ylo_bnd_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_yhi_bnd_h_avg{FieldLoc::CELL};
     amrex::Real m_liquid_vof_eps{1.0e-12_rt};
 
     amrex::Real m_relaxation{0.5_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -41,7 +41,7 @@ public:
 
 private:
     void update_target_velocity();
-    void compute_xlo_z_averages();
+    void compute_boundary_z_averages();
 
     const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;
@@ -51,7 +51,10 @@ private:
     const Field* m_vof{nullptr};
     bool m_vof_exists{false};
 
-    MultiLevelVector m_xline_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_ylo_uvof_avg{FieldLoc::CELL};
+    MultiLevelVector m_yhi_uvof_avg{FieldLoc::CELL};
     amrex::Real m_liquid_vof_eps{1.0e-12_rt};
 
     amrex::Real m_relaxation{0.5_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -77,26 +77,26 @@ private:
     amrex::Real m_velocity_scale_factor_max{2.0_rt};
     amrex::Real m_velocity_scale_factor_min{0.25_rt};
 
-    MultiLevelVector m_xlo_uliq{FieldLoc::CELL};
-    MultiLevelVector m_xhi_uliq{FieldLoc::CELL};
-    MultiLevelVector m_ylo_uliq{FieldLoc::CELL};
-    MultiLevelVector m_yhi_uliq{FieldLoc::CELL};
-    MultiLevelVector m_xlo_umix{FieldLoc::CELL};
-    MultiLevelVector m_xhi_umix{FieldLoc::CELL};
-    MultiLevelVector m_ylo_umix{FieldLoc::CELL};
-    MultiLevelVector m_yhi_umix{FieldLoc::CELL};
-    MultiLevelVector m_xlo_bnd_uvof{FieldLoc::CELL};
-    MultiLevelVector m_xhi_bnd_uvof{FieldLoc::CELL};
-    MultiLevelVector m_ylo_bnd_uvof{FieldLoc::CELL};
-    MultiLevelVector m_yhi_bnd_uvof{FieldLoc::CELL};
-    MultiLevelVector m_xlo_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_xhi_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_ylo_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_yhi_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_xlo_bnd_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_xhi_bnd_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_ylo_bnd_h_avg{FieldLoc::CELL};
-    MultiLevelVector m_yhi_bnd_h_avg{FieldLoc::CELL};
+    MultiLevelVector m_xlo_uhliq{FieldLoc::CELL};
+    MultiLevelVector m_xhi_uhliq{FieldLoc::CELL};
+    MultiLevelVector m_ylo_uhliq{FieldLoc::CELL};
+    MultiLevelVector m_yhi_uhliq{FieldLoc::CELL};
+    MultiLevelVector m_xlo_uhmix{FieldLoc::CELL};
+    MultiLevelVector m_xhi_uhmix{FieldLoc::CELL};
+    MultiLevelVector m_ylo_uhmix{FieldLoc::CELL};
+    MultiLevelVector m_yhi_uhmix{FieldLoc::CELL};
+    MultiLevelVector m_xlo_bnd_uh{FieldLoc::CELL};
+    MultiLevelVector m_xhi_bnd_uh{FieldLoc::CELL};
+    MultiLevelVector m_ylo_bnd_uh{FieldLoc::CELL};
+    MultiLevelVector m_yhi_bnd_uh{FieldLoc::CELL};
+    MultiLevelVector m_xlo_h{FieldLoc::CELL};
+    MultiLevelVector m_xhi_h{FieldLoc::CELL};
+    MultiLevelVector m_ylo_h{FieldLoc::CELL};
+    MultiLevelVector m_yhi_h{FieldLoc::CELL};
+    MultiLevelVector m_xlo_bnd_h{FieldLoc::CELL};
+    MultiLevelVector m_xhi_bnd_h{FieldLoc::CELL};
+    MultiLevelVector m_ylo_bnd_h{FieldLoc::CELL};
+    MultiLevelVector m_yhi_bnd_h{FieldLoc::CELL};
 };
 
 } // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -42,7 +42,13 @@ public:
 
     void update_flather_variables(const int lev, const FieldState fstate)
     {
-        compute_boundary_z_averages(lev, fstate);
+        compute_boundary_z_averages(lev, fstate, false);
+    }
+
+    void update_flather_variables(
+        const int lev, const FieldState fstate, const bool use_mac_fields)
+    {
+        compute_boundary_z_averages(lev, fstate, use_mac_fields);
     }
 
     void accumulate_boundary(
@@ -52,17 +58,22 @@ public:
         MultiLevelVector& out_uvec,
         MultiLevelVector& out_hvec,
         bool sample_boundary,
-        FieldState fstate) const;
+        FieldState fstate,
+        bool use_mac_fields = false) const;
 
 private:
     void compute_internal_z_averages();
-    void compute_boundary_z_averages(int lev, FieldState fstate);
+    void compute_boundary_z_averages(
+        int lev, FieldState fstate, bool use_mac_fields = false);
 
     const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
     Field& m_velocity;
+    Field& m_u_mac;
+    Field& m_v_mac;
+    Field& m_w_mac;
     const Field& m_vof;
     const IntField* m_terrain_blank{nullptr};
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -40,6 +40,8 @@ public:
         int dcomp = 0,
         int orig_comp = 0) const override;
 
+    void update_flather_variables(int lev) { compute_boundary_z_averages(lev); }
+
     void accumulate_boundary(
         int current_level,
         int idir,
@@ -49,8 +51,8 @@ public:
         bool sample_boundary) const;
 
 private:
-    void update_target_velocity();
-    void compute_boundary_z_averages();
+    void compute_internal_z_averages();
+    void compute_boundary_z_averages(int lev);
 
     const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -41,7 +41,7 @@ public:
         int orig_comp = 0) const override;
 
     void accumulate_boundary(
-        int lev,
+        int current_level,
         int idir,
         bool is_low,
         MultiLevelVector& out_uvec,

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -4,6 +4,7 @@
 #include "src/core/Field.H"
 #include "src/CFDSim.H"
 #include "src/boundary_conditions/field_boundary_fill/FieldBoundary.H"
+#include "src/utilities/MultiLevelVector.H"
 #include "src/utilities/trig_ops.H"
 #include "AMReX_REAL.H"
 #include <limits>
@@ -40,12 +41,18 @@ public:
 
 private:
     void update_target_velocity();
+    void compute_xlo_z_averages();
 
     const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
     Field& m_velocity;
+    const Field* m_vof{nullptr};
+    bool m_vof_exists{false};
+
+    MultiLevelVector m_xline_uvof_avg{FieldLoc::CELL};
+    amrex::Real m_liquid_vof_eps{1.0e-12_rt};
 
     amrex::Real m_relaxation{0.5_rt};
     amrex::Real m_target_weight{0.5_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -71,9 +71,8 @@ private:
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
     Field& m_velocity;
-    Field& m_u_mac;
-    Field& m_v_mac;
-    Field& m_w_mac;
+    const Field& m_u_mac;
+    const Field& m_v_mac;
     const Field& m_vof;
     const IntField* m_terrain_blank{nullptr};
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -40,13 +40,10 @@ public:
         int dcomp = 0,
         int orig_comp = 0) const override;
 
-    void update_flather_variables(const int lev, const FieldState fstate)
-    {
-        compute_boundary_z_averages(lev, fstate, false);
-    }
-
     void update_flather_variables(
-        const int lev, const FieldState fstate, const bool use_mac_fields)
+        const int lev,
+        const FieldState fstate,
+        const bool use_mac_fields = false)
     {
         compute_boundary_z_averages(lev, fstate, use_mac_fields);
     }

--- a/src/boundary_conditions/field_boundary_fill/Flather.H
+++ b/src/boundary_conditions/field_boundary_fill/Flather.H
@@ -51,6 +51,7 @@ private:
     Field& m_velocity;
     const Field& m_vof;
     const IntField* m_terrain_blank{nullptr};
+    amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};
 
     MultiLevelVector m_xlo_uvof_avg{FieldLoc::CELL};
     MultiLevelVector m_xhi_uvof_avg{FieldLoc::CELL};
@@ -68,18 +69,6 @@ private:
     MultiLevelVector m_xhi_bnd_h_avg{FieldLoc::CELL};
     MultiLevelVector m_ylo_bnd_h_avg{FieldLoc::CELL};
     MultiLevelVector m_yhi_bnd_h_avg{FieldLoc::CELL};
-    amrex::Real m_liquid_vof_eps{1.0e-12_rt};
-
-    amrex::Real m_relaxation{0.5_rt};
-    amrex::Real m_target_weight{0.5_rt};
-
-    amrex::Real m_wind_speed{8.0_rt};
-    amrex::Real m_wind_direction{270.0_rt};
-    amrex::Vector<amrex::Real> m_uvec{8.0_rt, 0.0_rt, 0.0_rt};
-
-    amrex::Real m_start_time{0.0_rt};
-    amrex::Real m_stop_time{std::numeric_limits<amrex::Real>::max()};
-    amrex::Real m_degrees_per_sec{0.0_rt};
 };
 
 } // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -3,6 +3,7 @@
 #include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
 #include "src/utilities/index_operations.H"
 #include "src/utilities/constants.H"
+#include "AMReX_MultiFabUtil.H"
 #include "AMReX_GpuAtomic.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_REAL.H"
@@ -33,14 +34,16 @@ Flather::Flather(CFDSim& sim)
     amrex::ParmParse pp("incflo");
     pp.queryarr("gravity", m_gravity);
 
-    m_xlo_uvof_avg.resize(0, m_mesh.Geom());
-    m_xhi_uvof_avg.resize(0, m_mesh.Geom());
-    m_ylo_uvof_avg.resize(1, m_mesh.Geom());
-    m_yhi_uvof_avg.resize(1, m_mesh.Geom());
-    m_xlo_bnd_uvof_avg.resize(0, m_mesh.Geom());
-    m_xhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
-    m_ylo_bnd_uvof_avg.resize(1, m_mesh.Geom());
-    m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
+    // Vector at the x boundary extends in y direction
+    // Vector at the y boundary extends in x direction
+    m_xlo_uvof_avg.resize(1, m_mesh.Geom());
+    m_xhi_uvof_avg.resize(1, m_mesh.Geom());
+    m_ylo_uvof_avg.resize(0, m_mesh.Geom());
+    m_yhi_uvof_avg.resize(0, m_mesh.Geom());
+    m_xlo_bnd_uvof_avg.resize(1, m_mesh.Geom());
+    m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
+    m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
+    m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
 }
 
 void Flather::post_init_actions()
@@ -52,7 +55,7 @@ void Flather::post_init_actions()
 void Flather::pre_advance_work() { compute_boundary_z_averages(); }
 
 void Flather::accumulate_boundary(
-    const int lev,
+    const int current_level,
     const int idir,
     const bool is_low,
     MultiLevelVector& out_uvec,
@@ -61,8 +64,8 @@ void Flather::accumulate_boundary(
 {
     AMREX_ALWAYS_ASSERT(idir == 0 || idir == 1);
 
-    auto& avg_h = out_uvec.host_data(lev);
-    auto& dist_h = out_hvec.host_data(lev);
+    auto& avg_h = out_uvec.host_data(current_level);
+    auto& dist_h = out_hvec.host_data(current_level);
     const int nline = static_cast<int>(avg_h.size());
 
     amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
@@ -70,60 +73,91 @@ void Flather::accumulate_boundary(
     amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
-    const auto& geom = m_mesh.Geom(lev);
-    const auto& dz = geom.CellSizeArray()[2];
-    const auto& dom = geom.Domain();
-    const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
-    const int off = dom.smallEnd(idir);
-    const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
-    if (shift_to_boundary != 0) {
-        AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
-        AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
-    }
     const amrex::Real tiny = constants::TIGHT_TOL;
 
-    const auto& vel_mf = m_velocity(lev);
+    // Loop through current level and all below
+    for (int lev = current_level; lev >= 0; --lev) {
+
+        const auto rr = m_mesh.refRatio(lev)[1 - idir];
+
+        amrex::iMultiFab level_mask;
+        if (lev < current_level) {
+            level_mask = makeFineMask(
+                m_mesh.boxArray(lev), m_mesh.DistributionMap(lev),
+                m_mesh.boxArray(lev + 1), m_mesh.refRatio(lev), 1, 0);
+        } else {
+            level_mask.define(
+                m_mesh.boxArray(lev), m_mesh.DistributionMap(lev), 1, 0,
+                amrex::MFInfo());
+            level_mask.setVal(1);
+        }
+
+        const auto& geom = m_mesh.Geom(lev);
+        const auto& dz = geom.CellSizeArray()[2];
+        const auto& dom = geom.Domain();
+        const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
+        const int off = dom.smallEnd(idir);
+        const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
+        if (shift_to_boundary != 0) {
+            AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
+            AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
+        }
+
+        const auto& vel_mf = m_velocity(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
-         ++mfi) {
-        amrex::Box bx = mfi.tilebox() & dom;
-        if (!bx.ok()) {
-            continue;
-        }
-        if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
-            continue;
-        }
-
-        bx.setSmall(idir, bidx);
-        bx.setBig(idir, bidx);
-
-        const auto vel_arr = vel_mf.const_array(mfi);
-        const auto vof_arr = m_vof(lev).const_array(mfi);
-        const bool use_terrain = (m_terrain_blank != nullptr);
-        const auto terrain_blank_arr =
-            use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
-                        : amrex::Array4<int const>();
-
-        amrex::Real* uvof_sum = uvof_sum_d.data();
-        amrex::Real* vof_sum = vof_sum_d.data();
-
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
-            const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
-
-            if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
-                return;
+        for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
+             ++mfi) {
+            amrex::Box bx = mfi.tilebox() & dom;
+            if (!bx.ok()) {
+                continue;
             }
-            const int idx = (idir == 0) ? (i - off) : (j - off);
-            const amrex::Real vf =
-                amrex::max(0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
-            amrex::Gpu::Atomic::Add(
-                &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
-            amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
-        });
+            if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
+                continue;
+            }
+
+            // Limit box to along boundary
+            bx.setSmall(idir, bidx);
+            bx.setBig(idir, bidx);
+
+            const auto vel_arr = vel_mf.const_array(mfi);
+            const auto vof_arr = m_vof(lev).const_array(mfi);
+            const auto mask_arr = level_mask.const_array(mfi);
+            const bool use_terrain = (m_terrain_blank != nullptr);
+            const auto terrain_blank_arr =
+                use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
+                            : amrex::Array4<int const>();
+
+            amrex::Real* uvof_sum = uvof_sum_d.data();
+            amrex::Real* vof_sum = vof_sum_d.data();
+
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
+                const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
+
+                if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
+                    return;
+                }
+                // This index is tangent to the boundary
+                const int idx_lev = (idir == 0) ? (j - off) : (i - off);
+                // Convert to current level indices
+                const int idx_min =
+                    idx_lev + idx_lev * (rr - 1) * (current_level - lev);
+                const int idx_max = idx_min + rr * (current_level - lev) - 1;
+
+                for (int idx = idx_min;
+                     idx <= amrex::max<int>(idx_min, idx_max); ++idx) {
+                    const auto liquid_height =
+                        vof_arr(ii, jj, k) * dz * mask_arr(ii, jj, k);
+                    amrex::Gpu::Atomic::Add(
+                        &uvof_sum[idx],
+                        vel_arr(ii, jj, k, idir) * liquid_height);
+                    amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
+                }
+            });
+        }
     }
 
     amrex::Gpu::copy(
@@ -137,8 +171,8 @@ void Flather::accumulate_boundary(
     amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
 
     for (int n = 0; n < nline; ++n) {
-        avg_h[n] = (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n])
-                                         : 0.0_rt;
+        avg_h[n] =
+            (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n]) : 0.0_rt;
         dist_h[n] = vof_sum_h[n];
     }
 }
@@ -150,14 +184,14 @@ void Flather::compute_boundary_z_averages()
     const int nlevels = m_repo.num_active_levels();
     const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
     if (m_xlo_uvof_avg.size() != nlevels_geom) {
-        m_xlo_uvof_avg.resize(0, m_mesh.Geom());
-        m_xhi_uvof_avg.resize(0, m_mesh.Geom());
-        m_ylo_uvof_avg.resize(1, m_mesh.Geom());
-        m_yhi_uvof_avg.resize(1, m_mesh.Geom());
-        m_xlo_bnd_uvof_avg.resize(0, m_mesh.Geom());
-        m_xhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
-        m_ylo_bnd_uvof_avg.resize(1, m_mesh.Geom());
-        m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
+        m_xlo_uvof_avg.resize(1, m_mesh.Geom());
+        m_xhi_uvof_avg.resize(1, m_mesh.Geom());
+        m_ylo_uvof_avg.resize(0, m_mesh.Geom());
+        m_yhi_uvof_avg.resize(0, m_mesh.Geom());
+        m_xlo_bnd_uvof_avg.resize(1, m_mesh.Geom());
+        m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
+        m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
+        m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
     }
 
     for (int lev = 0; lev < nlevels; ++lev) {

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -537,15 +537,16 @@ void Flather::set_velocity(
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
 
-                    bool interior_bounded = scale_interior > vscale_max ||
-                                            scale_interior < vscale_min;
+                    const bool interior_unbounded =
+                        scale_interior > vscale_max ||
+                        scale_interior < vscale_min;
                     // If scale is unbounded, override interior data
                     // (edge case 2)
-                    override_interior = !interior_bounded;
+                    override_interior = interior_unbounded;
                     // If scale is unbounded, revert to 1
                     // (part of edge case 3)
                     scale_interior =
-                        !interior_bounded ? 1.0_rt : scale_interior;
+                        interior_unbounded ? 1.0_rt : scale_interior;
                 }
 
                 // Never override interior with invalid boundary data

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -51,6 +51,98 @@ void Flather::post_init_actions()
 
 void Flather::pre_advance_work() { compute_boundary_z_averages(); }
 
+void Flather::accumulate_boundary(
+    const int lev,
+    const int idir,
+    const bool is_low,
+    MultiLevelVector& out_uvec,
+    MultiLevelVector& out_hvec,
+    const bool sample_boundary) const
+{
+    AMREX_ALWAYS_ASSERT(idir == 0 || idir == 1);
+
+    auto& avg_h = out_uvec.host_data(lev);
+    auto& dist_h = out_hvec.host_data(lev);
+    const int nline = static_cast<int>(avg_h.size());
+
+    amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
+    amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
+    amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
+    amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
+
+    const auto& geom = m_mesh.Geom(lev);
+    const auto& dz = geom.CellSizeArray()[2];
+    const auto& dom = geom.Domain();
+    const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
+    const int off = dom.smallEnd(idir);
+    const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
+    if (shift_to_boundary != 0) {
+        AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
+        AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
+    }
+    const amrex::Real tiny = constants::TIGHT_TOL;
+
+    const auto& vel_mf = m_velocity(lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
+         ++mfi) {
+        amrex::Box bx = mfi.tilebox() & dom;
+        if (!bx.ok()) {
+            continue;
+        }
+        if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
+            continue;
+        }
+
+        bx.setSmall(idir, bidx);
+        bx.setBig(idir, bidx);
+
+        const auto vel_arr = vel_mf.const_array(mfi);
+        const auto vof_arr = m_vof(lev).const_array(mfi);
+        const bool use_terrain = (m_terrain_blank != nullptr);
+        const auto terrain_blank_arr =
+            use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
+                        : amrex::Array4<int const>();
+
+        amrex::Real* uvof_sum = uvof_sum_d.data();
+        amrex::Real* vof_sum = vof_sum_d.data();
+
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
+            const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
+
+            if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
+                return;
+            }
+            const int idx = (idir == 0) ? (i - off) : (j - off);
+            const amrex::Real vf =
+                amrex::max(0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
+            amrex::Gpu::Atomic::Add(
+                &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
+            amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
+        });
+    }
+
+    amrex::Gpu::copy(
+        amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
+        uvof_sum_h.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
+        vof_sum_h.begin());
+
+    amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
+    amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
+
+    for (int n = 0; n < nline; ++n) {
+        avg_h[n] = (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n])
+                                         : 0.0_rt;
+        dist_h[n] = vof_sum_h[n];
+    }
+}
+
 void Flather::compute_boundary_z_averages()
 {
     BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
@@ -68,105 +160,22 @@ void Flather::compute_boundary_z_averages()
         m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
     }
 
-    auto accumulate_boundary = [&](const int lev, const int idir,
-                                   const bool is_low,
-                                   MultiLevelVector& out_uvec,
-                                   MultiLevelVector& out_hvec,
-                                   const bool sample_boundary) {
-        auto& avg_h = out_uvec.host_data(lev);
-        auto& dist_h = out_hvec.host_data(lev);
-        const int nline = static_cast<int>(avg_h.size());
-
-        amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
-        amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
-        amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
-        amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
-
-        const auto& geom = m_mesh.Geom(lev);
-        const auto& dz = geom.CellSizeArray()[2];
-        const auto& dom = geom.Domain();
-        const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
-        const int off = dom.smallEnd(idir);
-        const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
-        if (shift_to_boundary != 0) {
-            AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
-            AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
-        }
-        const amrex::Real tiny = constants::TIGHT_TOL;
-
-        const auto& vel_mf = m_velocity(lev);
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
-             ++mfi) {
-            amrex::Box bx = mfi.tilebox() & dom;
-            if (!bx.ok()) {
-                continue;
-            }
-            if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
-                continue;
-            }
-
-            bx.setSmall(idir, bidx);
-            bx.setBig(idir, bidx);
-
-            const auto vel_arr = vel_mf.const_array(mfi);
-            const auto vof_arr = m_vof(lev).const_array(mfi);
-            const bool use_terrain = (m_terrain_blank != nullptr);
-            const auto terrain_blank_arr =
-                use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
-                            : amrex::Array4<int const>();
-
-            amrex::Real* uvof_sum = uvof_sum_d.data();
-            amrex::Real* vof_sum = vof_sum_d.data();
-
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
-                const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
-
-                if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
-                    return;
-                }
-                const int idx = (idir == 0) ? (i - off) : (j - off);
-                const amrex::Real vf =
-                    amrex::max(0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
-                amrex::Gpu::Atomic::Add(
-                    &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
-                amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
-            });
-        }
-
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
-            uvof_sum_h.begin());
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
-            vof_sum_h.begin());
-
-        amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
-        amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
-
-        for (int n = 0; n < nline; ++n) {
-            avg_h[n] =
-                (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n]) : 0.0_rt;
-            dist_h[n] = vof_sum_h[n];
-        }
-    };
-
     for (int lev = 0; lev < nlevels; ++lev) {
-        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false);
-        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false);
-        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
-        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
-        accumulate_boundary(
+        this->accumulate_boundary(
+            lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false);
+        this->accumulate_boundary(
+            lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false);
+        this->accumulate_boundary(
+            lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
+        this->accumulate_boundary(
+            lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
+        this->accumulate_boundary(
             lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
-        accumulate_boundary(
+        this->accumulate_boundary(
             lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
-        accumulate_boundary(
+        this->accumulate_boundary(
             lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
-        accumulate_boundary(
+        this->accumulate_boundary(
             lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
     }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -3,6 +3,7 @@
 #include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
 #include "src/utilities/index_operations.H"
 #include "src/utilities/constants.H"
+#include "src/physics/multiphase/MultiPhase.H"
 #include "AMReX_MultiFabUtil.H"
 #include "AMReX_GpuAtomic.H"
 #include "AMReX_ParmParse.H"
@@ -31,6 +32,11 @@ Flather::Flather(CFDSim& sim)
     }
     if (m_repo.int_field_exists("terrain_blank")) {
         m_terrain_blank = &m_repo.get_int_field("terrain_blank");
+    }
+
+    if (m_sim.physics_manager().contains("MultiPhase")) {
+        m_rho1 = m_sim.physics_manager().get<kynema_sgf::MultiPhase>().rho1();
+        m_rho2 = m_sim.physics_manager().get<kynema_sgf::MultiPhase>().rho2();
     }
 
     amrex::ParmParse pp("incflo");
@@ -323,6 +329,8 @@ void Flather::set_velocity(
     const amrex::Real tiny = constants::TIGHT_TOL;
     const amrex::Real v_threshold = 1.0e-6_rt;
     const auto grav_z = -m_gravity[2];
+    const auto rho1 = m_rho1;
+    const auto rho2 = m_rho2;
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         const auto ori = oit();
@@ -478,7 +486,14 @@ void Flather::set_velocity(
                 const bool inflow_liq = !outflow && boundary_vof > tiny;
                 const bool outflow_liq = outflow && interior_vof > tiny;
                 if (outflow_liq || inflow_liq) {
-                    arr(iv, fcomp) = scaled_vel;
+                    const amrex::Real upstream_vof =
+                        outflow_liq ? interior_vof : boundary_vof;
+                    const amrex::Real upstream_density =
+                        upstream_vof * rho1 + (1.0_rt - upstream_vof) * rho2;
+                    arr(iv, fcomp) =
+                        (rho1 * upstream_vof * scaled_vel +
+                         rho2 * (1.0_rt - upstream_vof) * local_vel) /
+                        upstream_density;
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -25,8 +25,6 @@ Flather::Flather(CFDSim& sim)
     , m_v_mac(m_sim.repo().get_field("v_mac"))
     , m_vof(m_sim.repo().get_field("vof"))
 {
-    // amrex::ParmParse pp(identifier());
-
     if (!m_repo.field_exists("vof")) {
         amrex::Abort("Flather BC requires the vof field");
     }
@@ -495,14 +493,14 @@ void Flather::set_velocity(
                     boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
                                        (interior_h - boundary_h);
 
-                // Use external (prescribed) velocity if inflow
-                // Assesses inflow by the whole column, not the local value
-                // Assumes values are up-to-date from another fillpatch op
+                // Use external (prescribed) velocity if inflow:
+                // - Assesses inflow by the whole column, not the local value
+                // - Assumes values are up-to-date from another fillpatch op
                 const bool prescribed_inflow =
                     ori.isLow() ? boundary_val > 0.0_rt : boundary_val < 0.0_rt;
 
                 // Clip the velocity in the interior to prevent inflow at
-                // outflow, this is consistent with the line integral
+                // outflow; this is consistent with the line integral
                 // calculations
                 const auto local_internal_vel =
                     ori.isLow() ? amrex::min(ref_arr(iv_adj_cc, idir), 0.0_rt)
@@ -510,25 +508,26 @@ void Flather::set_velocity(
 
                 // Normal outflow case:
                 // *) For a given column, apply scale to the interior velocity,
-                // but only
-                //    to fully liquid cells; leave mixed cells unchanged.
+                //    but only to fully liquid cells; leave mixed cells
+                //    unchanged.
 
                 // Edge cases:
-                // 1) If the boundary contains no liquid, the flather can be
-                // very large.
-                //    Use a regular outflow (Neumann) condition.
+                // 1) If the boundary contains no liquid, the Flather velocity
+                //    can be very large. Use a regular outflow (Neumann)
+                //    condition.
+
                 // 2) If the interior column contains no fully liquid cells,
-                // there is
-                //    nothing to scale. Instead of scaling the internal profile,
-                //    override the interior velocity with scaled external
-                //    profile.
+                //    there is nothing to scale. Instead of scaling the internal
+                //    profile, override the interior velocity with scaled
+                //    external profile.
+
                 // 3) If the boundary velocity is 0, then the scaling based on
-                //    external quantities is undefined. Keep the scale_interior
-                //    = 1
+                //    external quantities is undefined. Keep scale_interior = 1.
+
                 // 4) During initialization, the scaling can be very aggressive.
                 //    Plus, when the internal and external profiles are very
                 //    different, the scaling can lead to rapid acceleration.
-                //    Switch to the external profile when the changes are rapid
+                //    Switch to the external profile when the changes are rapid.
 
                 bool override_interior = false;
                 auto scale_interior = 1.0_rt;
@@ -543,12 +542,6 @@ void Flather::set_velocity(
                     override_interior = true;
                 }
 
-                /*
-                // Limit the scaling factor to prevent overly aggressive changes
-                scale_interior =
-                    amrex::max(0.5_rt, amrex::min(scale_interior, 1.2_rt));
-                */
-
                 auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;
                 if (prescribed_inflow || override_interior) {
@@ -559,7 +552,7 @@ void Flather::set_velocity(
                     scaled_vel = local_vel * scale_interior;
                 }
 
-                // Only use if advecting liquid (or zero velocity)
+                // Only use if advecting liquid (or zero velocity):
                 // This is important because the averages used to calculate
                 // the Flather velocity are only performed on cells containing
                 // liquid; therefore, the scaling of the velocity is only valid

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -1,0 +1,144 @@
+#include "src/CFDSim.H"
+#include "src/boundary_conditions/field_boundary_fill/Flather.H"
+#include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
+#include "src/utilities/index_operations.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_REAL.H"
+#include <algorithm>
+#include <cmath>
+
+using namespace amrex::literals;
+
+namespace kynema_sgf {
+
+Flather::Flather(CFDSim& sim)
+    : m_sim(sim)
+    , m_time(m_sim.time())
+    , m_repo(m_sim.repo())
+    , m_mesh(m_sim.mesh())
+    , m_velocity(m_sim.repo().get_field("velocity"))
+{
+    amrex::ParmParse pp(identifier());
+
+    pp.query("relaxation", m_relaxation);
+    pp.query("target_weight", m_target_weight);
+    pp.query("wind_speed", m_wind_speed);
+    pp.query("wind_direction", m_wind_direction);
+    pp.query("start_time", m_start_time);
+    pp.query("stop_time", m_stop_time);
+    pp.query("degrees_per_second", m_degrees_per_sec);
+
+    update_target_velocity();
+}
+
+void Flather::post_init_actions()
+{
+    m_velocity.register_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
+}
+
+void Flather::pre_advance_work()
+{
+#ifdef KYNEMA_SGF_USE_HELICS
+    if (m_sim.helics().is_activated()) {
+        m_wind_speed = m_sim.helics().m_inflow_wind_speed_to_kynema_sgf;
+        m_wind_direction =
+            -m_sim.helics().m_inflow_wind_direction_to_kynema_sgf + 270.0_rt;
+        update_target_velocity();
+        return;
+    }
+#endif
+
+    if (m_time.current_time() > m_start_time &&
+        m_time.current_time() < m_stop_time) {
+        m_wind_direction -= m_degrees_per_sec * m_time.delta_t();
+    }
+    update_target_velocity();
+}
+
+void Flather::set_velocity(
+    const int lev,
+    const amrex::Real /*time*/,
+    const Field& fld,
+    amrex::MultiFab& mfab,
+    const int dcomp,
+    const int orig_comp) const
+{
+    BL_PROFILE("kynema-sgf::Flather::set_velocity");
+
+    const amrex::Real relax = amrex::max(
+        0.0_rt, amrex::min<amrex::Real>(1.0_rt, m_relaxation));
+    const amrex::Real target_weight = amrex::max(
+        0.0_rt, amrex::min<amrex::Real>(1.0_rt, m_target_weight));
+
+    const amrex::Real tvx = m_uvec[0];
+    const amrex::Real tvy = m_uvec[1];
+    const amrex::Real tvz = m_uvec[2];
+
+    const auto& geom = m_mesh.Geom(lev);
+    const auto& bctype = fld.bc_type();
+    const int nghost = 1;
+    const auto& domain = geom.growPeriodicDomain(nghost);
+
+    for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
+        const auto ori = oit();
+        if ((bctype[ori] != BC::mass_inflow) &&
+            (bctype[ori] != BC::mass_inflow_outflow)) {
+            continue;
+        }
+
+        const int idir = ori.coordDir();
+        const auto& dbx = ori.isLow() ? amrex::adjCellLo(domain, idir, nghost)
+                                      : amrex::adjCellHi(domain, idir, nghost);
+        const auto shift_to_interior =
+            amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (false)
+#endif
+        for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi) {
+            auto gbx = amrex::grow(mfi.validbox(), nghost);
+            const auto& bx =
+                utils::face_aware_boundary_box_intersection(gbx, dbx, ori);
+            if (!bx.ok()) {
+                continue;
+            }
+
+            const auto& arr = mfab[mfi].array();
+            const int numcomp = mfab.nComp();
+
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                const amrex::IntVect iv{i, j, k};
+                const amrex::IntVect iv_adj = iv + shift_to_interior;
+                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> target_vel =
+                    {AMREX_D_DECL(tvx, tvy, tvz)};
+
+                for (int n = 0; n < numcomp; ++n) {
+                    const amrex::Real boundary_old = arr(iv, dcomp + n);
+                    const amrex::Real interior_val = arr(iv_adj, dcomp + n);
+                    const amrex::Real target_val = target_vel[orig_comp + n];
+
+                    const amrex::Real desired =
+                        ((1.0_rt - target_weight) * interior_val) +
+                        (target_weight * target_val);
+
+                    arr(iv, dcomp + n) =
+                        ((1.0_rt - relax) * boundary_old) + (relax * desired);
+                }
+            });
+        }
+    }
+}
+
+void Flather::update_target_velocity()
+{
+    const amrex::Real wind_speed = m_wind_speed;
+    const amrex::Real wind_direction = -m_wind_direction + 270.0_rt;
+    const amrex::Real wind_direction_radian =
+        kynema_sgf::utils::radians(wind_direction);
+
+    m_uvec[0] = wind_speed * std::cos(wind_direction_radian);
+    m_uvec[1] = wind_speed * std::sin(wind_direction_radian);
+    m_uvec[2] = 0.0_rt;
+}
+
+} // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -153,6 +153,8 @@ void Flather::accumulate_boundary(
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
                 const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
+                const int ii_v = ii + static_cast<int>(idir == 0 && !is_low);
+                const int jj_v = jj + static_cast<int>(idir == 1 && !is_low);
 
                 if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
                     return;
@@ -171,7 +173,7 @@ void Flather::accumulate_boundary(
                         vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
                     amrex::Gpu::Atomic::Add(
                         &uvof_sum[idx],
-                        vel_arr(ii, jj, k, use_mac_fields ? 0 : idir) *
+                        vel_arr(ii_v, jj_v, k, use_mac_fields ? 0 : idir) *
                             liquid_height);
                     amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
                 }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -497,8 +497,10 @@ void Flather::set_velocity(
                 const amrex::Real c = std::sqrt(grav_z * interior_h);
 
                 const auto Flather_val =
-                    boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
-                                       (interior_h - boundary_h);
+                    boundary_h > tiny
+                        ? boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
+                                             (interior_h - boundary_h)
+                        : 0.0_rt;
 
                 // Use external (prescribed) velocity if inflow
                 // Assesses inflow by the whole column, not the local value

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -42,6 +42,10 @@ Flather::Flather(CFDSim& sim)
     m_xhi_uvof_avg.resize(0, m_mesh.Geom());
     m_ylo_uvof_avg.resize(1, m_mesh.Geom());
     m_yhi_uvof_avg.resize(1, m_mesh.Geom());
+    m_xlo_bnd_uvof_avg.resize(0, m_mesh.Geom());
+    m_xhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+    m_ylo_bnd_uvof_avg.resize(1, m_mesh.Geom());
+    m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
 
     update_target_velocity();
 }
@@ -84,13 +88,18 @@ void Flather::compute_boundary_z_averages()
         m_xhi_uvof_avg.resize(0, m_mesh.Geom());
         m_ylo_uvof_avg.resize(1, m_mesh.Geom());
         m_yhi_uvof_avg.resize(1, m_mesh.Geom());
+        m_xlo_bnd_uvof_avg.resize(0, m_mesh.Geom());
+        m_xhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+        m_ylo_bnd_uvof_avg.resize(1, m_mesh.Geom());
+        m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
     }
 
     auto accumulate_boundary =
         [&](const int lev,
             const int idir,
             const bool is_low,
-            MultiLevelVector& out_vec) {
+            MultiLevelVector& out_vec,
+            const bool sample_boundary) {
             auto& avg_h = out_vec.host_data(lev);
             const int nline = static_cast<int>(avg_h.size());
 
@@ -103,6 +112,12 @@ void Flather::compute_boundary_z_averages()
             const auto& dom = geom.Domain();
             const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
             const int off = dom.smallEnd(idir);
+            const int shift_to_boundary =
+                sample_boundary ? (is_low ? -1 : 1) : 0;
+            if (shift_to_boundary != 0) {
+                AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
+                AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
+            }
             const amrex::Real vof_eps = amrex::max(0.0_rt, m_liquid_vof_eps);
 
             const auto& vel_mf = m_velocity(lev);
@@ -135,14 +150,17 @@ void Flather::compute_boundary_z_averages()
 
                 amrex::ParallelFor(
                     bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
+                        const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
+
                         if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
                             return;
                         }
                         const int idx = (idir == 0) ? (i - off) : (j - off);
                         const amrex::Real vf = amrex::max(
-                            0.0_rt, amrex::min(1.0_rt, vof_arr(i, j, k)));
+                            0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
                         amrex::Gpu::Atomic::Add(
-                            &uvof_sum[idx], vel_arr(i, j, k, idir) * vf);
+                            &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf);
                         amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);
                     });
             }
@@ -165,16 +183,24 @@ void Flather::compute_boundary_z_averages()
         };
 
     for (int lev = 0; lev < nlevels; ++lev) {
-        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg);
-        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg);
-        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg);
-        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg);
+        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg, false);
+        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg, false);
+        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg, false);
+        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg, false);
+        accumulate_boundary(lev, 0, true, m_xlo_bnd_uvof_avg, true);
+        accumulate_boundary(lev, 0, false, m_xhi_bnd_uvof_avg, true);
+        accumulate_boundary(lev, 1, true, m_ylo_bnd_uvof_avg, true);
+        accumulate_boundary(lev, 1, false, m_yhi_bnd_uvof_avg, true);
     }
 
     m_xlo_uvof_avg.copy_host_to_device();
     m_xhi_uvof_avg.copy_host_to_device();
     m_ylo_uvof_avg.copy_host_to_device();
     m_yhi_uvof_avg.copy_host_to_device();
+    m_xlo_bnd_uvof_avg.copy_host_to_device();
+    m_xhi_bnd_uvof_avg.copy_host_to_device();
+    m_ylo_bnd_uvof_avg.copy_host_to_device();
+    m_yhi_bnd_uvof_avg.copy_host_to_device();
 }
 
 void Flather::set_velocity(
@@ -221,6 +247,14 @@ void Flather::set_velocity(
         const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
         const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
         const amrex::Real* yhi_uavg = m_yhi_uvof_avg.device_data(lev).data();
+        const amrex::Real* xlo_bnd_uavg =
+            m_xlo_bnd_uvof_avg.device_data(lev).data();
+        const amrex::Real* xhi_bnd_uavg =
+            m_xhi_bnd_uvof_avg.device_data(lev).data();
+        const amrex::Real* ylo_bnd_uavg =
+            m_ylo_bnd_uvof_avg.device_data(lev).data();
+        const amrex::Real* yhi_bnd_uavg =
+            m_yhi_bnd_uvof_avg.device_data(lev).data();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (false)
@@ -243,16 +277,22 @@ void Flather::set_velocity(
                     {AMREX_D_DECL(tvx, tvy, tvz)};
 
                 for (int n = 0; n < numcomp; ++n) {
-                    const amrex::Real boundary_old = arr(iv, dcomp + n);
+                    amrex::Real boundary_old = arr(iv, dcomp + n);
                     amrex::Real interior_val = arr(iv_adj, dcomp + n);
                     if (use_x && (orig_comp + n == 0)) {
                         interior_val = ori.isLow()
                                            ? xlo_uavg[iv_adj[0] - xoff]
                                            : xhi_uavg[iv_adj[0] - xoff];
+                        boundary_old = ori.isLow()
+                                           ? xlo_bnd_uavg[iv_adj[0] - xoff]
+                                           : xhi_bnd_uavg[iv_adj[0] - xoff];
                     } else if (use_y && (orig_comp + n == 1)) {
                         interior_val = ori.isLow()
                                            ? ylo_uavg[iv_adj[1] - yoff]
                                            : yhi_uavg[iv_adj[1] - yoff];
+                        boundary_old = ori.isLow()
+                                           ? ylo_bnd_uavg[iv_adj[1] - yoff]
+                                           : yhi_bnd_uavg[iv_adj[1] - yoff];
                     }
                     const amrex::Real target_val = target_vel[orig_comp + n];
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -536,7 +536,7 @@ void Flather::set_velocity(
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
-                } else if (std::abs(boundary_val) < v_threshold * boundary_h) {
+                } else if (std::abs(boundary_val) > v_threshold * boundary_h) {
                     override_interior = true;
                 }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -509,37 +509,48 @@ void Flather::set_velocity(
                 //    unchanged.
 
                 // Edge cases:
-                // 1) If the boundary velocity is 0, then the scaling based on
-                //    external quantities is undefined. Keep scale_interior = 1.
-                // 2) If the interior column contains no fully liquid cells,
+                // 1) If the interior column contains no fully liquid cells,
                 //    there is nothing to scale. Instead of scaling the internal
                 //    profile, override the interior velocity with scaled
                 //    external profile.
-                // 3) During initialization, the scaling can be very aggressive.
+                // 2) During initialization, the scaling can be very aggressive.
                 //    Plus, when the internal and external profiles are very
                 //    different, the scaling can lead to rapid acceleration.
                 //    Switch to the external profile when the changes are rapid.
+                // 3) If the boundary velocity is 0, then the scaling based on
+                //    external quantities is undefined. Use a regular outflow
+                //    (Neumann) condition, even if edge cases 1) or 2) apply.
                 // 4) If the boundary contains no liquid, the Flather velocity
                 //    can be very large. Use a regular outflow (Neumann)
                 //    condition.
 
-                bool override_interior = false;
-                // Edge case 1 (when both conditions are false)
+                bool interior_valid =
+                    std::abs(interior_liq) > v_threshold * interior_h;
+                bool boundary_valid =
+                    std::abs(boundary_val) > v_threshold * boundary_h;
+
+                // Use boundary data by default (edge case 1)
+                bool override_interior = true;
                 auto scale_interior = 1.0_rt;
-                if (std::abs(interior_liq) > v_threshold * interior_h) {
-                    // Normal case
+                if (interior_valid) {
+                    // Normal case: calculate velocity scale with Flather
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
-                } else if (std::abs(boundary_val) > v_threshold * boundary_h) {
-                    // Edge case 2
-                    override_interior = true;
+
+                    bool interior_bounded = scale_interior > vscale_max ||
+                                            scale_interior < vscale_min;
+                    // If scale is unbounded, override interior data
+                    // (edge case 2)
+                    override_interior = !interior_bounded;
+                    // If scale is unbounded, revert to 1
+                    // (part of edge case 3)
+                    scale_interior =
+                        !interior_bounded ? 1.0_rt : scale_interior;
                 }
 
-                if (scale_interior > vscale_max ||
-                    scale_interior < vscale_min) {
-                    // Edge case 3
-                    override_interior = true;
-                }
+                // Never override interior with invalid boundary data
+                // (part of edge case 3)
+                override_interior = override_interior && boundary_valid;
 
                 auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;
@@ -565,7 +576,7 @@ void Flather::set_velocity(
                                           (outflow && override_interior))) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
-                    // Edge case 4 (boundary_h <= tiny)
+                    // edge case 4 (boundary_h <= tiny)
                     arr(iv, fcomp) = local_vel;
                 }
             });

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -517,7 +517,7 @@ void Flather::set_velocity(
                 if (prescribed_inflow) {
                     scaled_vel = local_vel * (Flather_val / boundary_val);
                 } else {
-                    if (std::abs(interior_val) > v_threshold * interior_h) {
+                    if (std::abs(interior_liq) > v_threshold * interior_h) {
                         scaled_vel = local_vel * ((Flather_val - interior_mix) /
                                                   interior_liq);
                     } else {
@@ -535,7 +535,9 @@ void Flather::set_velocity(
                 const bool inflow_any_liq = !outflow && boundary_vof > tiny;
                 const bool outflow_only_liq =
                     outflow && interior_vof < 1.0_rt - tiny;
-                if (outflow_only_liq || inflow_any_liq) {
+                if (outflow_only_liq || inflow_any_liq ||
+                    (outflow &&
+                     std::abs(interior_liq) <= v_threshold * interior_h)) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
                     arr(iv, fcomp) = local_vel;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -506,16 +506,37 @@ void Flather::set_velocity(
                 const bool prescribed_inflow =
                     ori.isLow() ? boundary_val > 0.0_rt : boundary_val < 0.0_rt;
 
+                // Clip the velocity in the interior to prevent inflow at
+                // outflow, this is consistent with the line integral
+                // calculations
                 const auto local_internal_vel =
                     ori.isLow() ? amrex::min(ref_arr(iv_adj_cc, idir), 0.0_rt)
                                 : amrex::max(ref_arr(iv_adj_cc, idir), 0.0_rt);
+
+                // Normal outflow case:
+                // *) For a given column, apply scale to the interior velocity,
+                // but only
+                //    to fully liquid cells; leave mixed cells unchanged.
+
+                // Edge cases:
+                // 1) If the boundary contains no liquid, the flather can be
+                // very large.
+                //    Use a regular outflow (Neumann) condition.
+                // 2) If the interior column contains no fully liquid cells,
+                // there is
+                //    nothing to scale. Instead of scaling the internal profile,
+                //    override the interior velocity with scaled external
+                //    profile.
+                // 3) If the boundary velocity is 0, then the scaling based on
+                //    external quantities is undefined. Keep the scale_interior
+                //    = 1
 
                 bool override_interior = false;
                 auto scale_interior = 1.0;
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
-                } else {
+                } else if (std::abs(boundary_val) < v_threshold * boundary_h) {
                     override_interior = true;
                 }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -116,7 +116,8 @@ void Flather::accumulate_boundary(
             AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
         }
 
-        const auto& vel_mf = src_vel.state(fstate)(lev);
+        const auto& vel_mf =
+            src_vel.state(use_mac_fields ? FieldState::New : fstate)(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -18,6 +18,7 @@ Flather::Flather(CFDSim& sim)
     , m_repo(m_sim.repo())
     , m_mesh(m_sim.mesh())
     , m_velocity(m_sim.repo().get_field("velocity"))
+    , m_vof(m_sim.repo().get_field("vof"))
 {
     amrex::ParmParse pp(identifier());
 
@@ -30,9 +31,8 @@ Flather::Flather(CFDSim& sim)
     pp.query("degrees_per_second", m_degrees_per_sec);
     pp.query("liquid_vof_eps", m_liquid_vof_eps);
 
-    m_vof_exists = m_repo.field_exists("vof");
-    if (m_vof_exists) {
-        m_vof = &m_repo.get_field("vof");
+    if (!m_repo.field_exists("vof")) {
+        amrex::Abort("Flather BC requires the vof field");
     }
 
     m_xlo_uvof_avg.resize(0, m_mesh.Geom());
@@ -121,10 +121,7 @@ void Flather::compute_boundary_z_averages()
                 bx.setBig(idir, bidx);
 
                 const auto vel_arr = vel_mf.const_array(mfi);
-                const bool include_vof = m_vof_exists;
-                const auto vof_arr =
-                    include_vof ? (*m_vof)(lev).const_array(mfi)
-                                : amrex::Array4<amrex::Real const>();
+                const auto vof_arr = m_vof(lev).const_array(mfi);
 
                 amrex::Real* uvof_sum = uvof_sum_d.data();
                 amrex::Real* vof_sum = vof_sum_d.data();
@@ -132,12 +129,8 @@ void Flather::compute_boundary_z_averages()
                 amrex::ParallelFor(
                     bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                         const int idx = (idir == 0) ? (i - off) : (j - off);
-                        const amrex::Real vf =
-                            include_vof
-                                ? amrex::max(
-                                      0.0_rt,
-                                      amrex::min(1.0_rt, vof_arr(i, j, k)))
-                                : 1.0_rt;
+                        const amrex::Real vf = amrex::max(
+                            0.0_rt, amrex::min(1.0_rt, vof_arr(i, j, k)));
                         amrex::Gpu::Atomic::Add(
                             &uvof_sum[idx], vel_arr(i, j, k, idir) * vf);
                         amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -134,7 +134,10 @@ void Flather::accumulate_boundary(
 #endif
         for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
              ++mfi) {
-            amrex::Box bx = mfi.tilebox() & dom;
+            // Iterate in cell-centered index space, even for MAC fields, so
+            // the box type matches the domain and the ii_v/jj_v face offsets
+            amrex::Box bx =
+                mfi.tilebox(amrex::IntVect::TheZeroVector()) & dom;
             if (!bx.ok()) {
                 continue;
             }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -179,8 +179,7 @@ void Flather::accumulate_boundary(
     amrex::ParallelDescriptor::ReduceRealSum(dist_h.data(), nline);
 
     for (int n = 0; n < nline; ++n) {
-        avg_h[n] =
-            (dist_h[n] > tiny) ? (uvof_sum_h[n] / dist_h[n]) : 0.0_rt;
+        avg_h[n] = (dist_h[n] > tiny) ? (uvof_sum_h[n] / dist_h[n]) : 0.0_rt;
     }
 }
 
@@ -336,33 +335,31 @@ void Flather::set_velocity(
                     amrex::Real interior_val = arr(iv_adj, dcomp + n);
                     amrex::Real boundary_h = 0.0_rt;
                     amrex::Real interior_h = 0.0_rt;
+                    // Vectors at x boundaries extend in y direction
+                    // Vectors at y boundaries extend in x direction
                     if (use_x && (orig_comp + n == 0)) {
-                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[0] - xoff]
-                                                   : xhi_uavg[iv_adj[0] - xoff];
-                        interior_h = ori.isLow() ? xlo_havg[iv_adj[0] - xoff]
-                                                 : xhi_havg[iv_adj[0] - xoff];
-                        boundary_val = ori.isLow()
-                                           ? xlo_bnd_uavg[iv_adj[0] - xoff]
-                                           : xhi_bnd_uavg[iv_adj[0] - xoff];
-                        boundary_h = ori.isLow()
-                                         ? xlo_bnd_havg[iv_adj[0] - xoff]
-                                         : xhi_bnd_havg[iv_adj[0] - xoff];
+                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[1] - xoff]
+                                                   : xhi_uavg[iv_adj[1] - xoff];
+                        interior_h = ori.isLow() ? xlo_havg[iv_adj[1] - xoff]
+                                                 : xhi_havg[iv_adj[1] - xoff];
+                        boundary_val = ori.isLow() ? xlo_bnd_uavg[iv[1] - xoff]
+                                                   : xhi_bnd_uavg[iv[1] - xoff];
+                        boundary_h = ori.isLow() ? xlo_bnd_havg[iv[1] - xoff]
+                                                 : xhi_bnd_havg[iv[1] - xoff];
                     } else if (use_y && (orig_comp + n == 1)) {
-                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[1] - yoff]
-                                                   : yhi_uavg[iv_adj[1] - yoff];
-                        interior_h = ori.isLow() ? ylo_havg[iv_adj[1] - yoff]
-                                                 : yhi_havg[iv_adj[1] - yoff];
-                        boundary_val = ori.isLow()
-                                           ? ylo_bnd_uavg[iv_adj[1] - yoff]
-                                           : yhi_bnd_uavg[iv_adj[1] - yoff];
-                        boundary_h = ori.isLow()
-                                         ? ylo_bnd_havg[iv_adj[1] - yoff]
-                                         : yhi_bnd_havg[iv_adj[1] - yoff];
+                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[0] - yoff]
+                                                   : yhi_uavg[iv_adj[0] - yoff];
+                        interior_h = ori.isLow() ? ylo_havg[iv_adj[0] - yoff]
+                                                 : yhi_havg[iv_adj[0] - yoff];
+                        boundary_val = ori.isLow() ? ylo_bnd_uavg[iv[0] - yoff]
+                                                   : yhi_bnd_uavg[iv[0] - yoff];
+                        boundary_h = ori.isLow() ? ylo_bnd_havg[iv[0] - yoff]
+                                                 : yhi_bnd_havg[iv[0] - yoff];
                     }
 
                     // Set velocity to zero and skip for terrain
-                    if (use_terrain && terrain_blank_arr(iv) != 0) {
-                        arr(iv_adj, dcomp + n) = 0.0_rt;
+                    if (use_terrain && terrain_blank_arr(iv_adj) != 0) {
+                        arr(iv, dcomp + n) = 0.0_rt;
                         continue;
                     }
                     // Check interior or boundary vof for liquid
@@ -381,8 +378,8 @@ void Flather::set_velocity(
                                            boundary_h *
                                            (interior_h - boundary_h);
 
-                    arr(iv_adj, dcomp + n) =
-                        arr(iv, dcomp + n) * (Flather_val / interior_val);
+                    arr(iv, dcomp + n) =
+                        arr(iv_adj, dcomp + n) * (Flather_val / interior_val);
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -249,7 +249,7 @@ void Flather::compute_boundary_z_averages()
 
 void Flather::set_velocity(
     const int lev,
-    const amrex::Real /*time*/,
+    const amrex::Real time,
     const Field& fld,
     amrex::MultiFab& mfab,
     const int dcomp,
@@ -263,6 +263,7 @@ void Flather::set_velocity(
     const int numcomp = mfab.nComp();
     const auto& domain = geom.growPeriodicDomain(nghost);
 
+    const auto fstate = time > 0.0_rt ? FieldState::Old : FieldState::New;
     const amrex::Real tiny = constants::TIGHT_TOL;
     const auto grav_z = -m_gravity[2];
 
@@ -331,8 +332,9 @@ void Flather::set_velocity(
             }
 
             const auto& arr = mfab[mfi].array();
+            const auto& ref_arr = fld.state(fstate)(lev)[mfi].const_array();
 
-            const auto vof_arr = m_vof(lev).const_array(mfi);
+            const auto vof_arr = m_vof.state(fstate)(lev).const_array(mfi);
             const bool use_terrain = (m_terrain_blank != nullptr);
             const auto terrain_blank_arr =
                 use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
@@ -389,7 +391,7 @@ void Flather::set_velocity(
                                        boundary_h * (interior_h - boundary_h);
 
                 const auto scaled_interior_vel =
-                    arr(iv_adj, fcomp) * (Flather_val / interior_val);
+                    ref_arr(iv_adj, idir) * (Flather_val / interior_val);
 
                 // Only use if pointing outward or pulling liquid in
                 // Zero velocity is fine either way

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -2,6 +2,7 @@
 #include "src/boundary_conditions/field_boundary_fill/Flather.H"
 #include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
 #include "src/utilities/index_operations.H"
+#include "src/utilities/constants.H"
 #include "AMReX_GpuAtomic.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_REAL.H"
@@ -20,16 +21,7 @@ Flather::Flather(CFDSim& sim)
     , m_velocity(m_sim.repo().get_field("velocity"))
     , m_vof(m_sim.repo().get_field("vof"))
 {
-    amrex::ParmParse pp(identifier());
-
-    pp.query("relaxation", m_relaxation);
-    pp.query("target_weight", m_target_weight);
-    pp.query("wind_speed", m_wind_speed);
-    pp.query("wind_direction", m_wind_direction);
-    pp.query("start_time", m_start_time);
-    pp.query("stop_time", m_stop_time);
-    pp.query("degrees_per_second", m_degrees_per_sec);
-    pp.query("liquid_vof_eps", m_liquid_vof_eps);
+    // amrex::ParmParse pp(identifier());
 
     if (!m_repo.field_exists("vof")) {
         amrex::Abort("Flather BC requires the vof field");
@@ -37,6 +29,9 @@ Flather::Flather(CFDSim& sim)
     if (m_repo.int_field_exists("terrain_blank")) {
         m_terrain_blank = &m_repo.get_int_field("terrain_blank");
     }
+
+    amrex::ParmParse pp("incflo");
+    pp.queryarr("gravity", m_gravity);
 
     m_xlo_uvof_avg.resize(0, m_mesh.Geom());
     m_xhi_uvof_avg.resize(0, m_mesh.Geom());
@@ -46,8 +41,6 @@ Flather::Flather(CFDSim& sim)
     m_xhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
     m_ylo_bnd_uvof_avg.resize(1, m_mesh.Geom());
     m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
-
-    update_target_velocity();
 }
 
 void Flather::post_init_actions()
@@ -56,26 +49,7 @@ void Flather::post_init_actions()
     compute_boundary_z_averages();
 }
 
-void Flather::pre_advance_work()
-{
-#ifdef KYNEMA_SGF_USE_HELICS
-    if (m_sim.helics().is_activated()) {
-        m_wind_speed = m_sim.helics().m_inflow_wind_speed_to_kynema_sgf;
-        m_wind_direction =
-            -m_sim.helics().m_inflow_wind_direction_to_kynema_sgf + 270.0_rt;
-        update_target_velocity();
-        compute_boundary_z_averages();
-        return;
-    }
-#endif
-
-    if (m_time.current_time() > m_start_time &&
-        m_time.current_time() < m_stop_time) {
-        m_wind_direction -= m_degrees_per_sec * m_time.delta_t();
-    }
-    update_target_velocity();
-    compute_boundary_z_averages();
-}
+void Flather::pre_advance_work() { compute_boundary_z_averages(); }
 
 void Flather::compute_boundary_z_averages()
 {
@@ -94,109 +68,106 @@ void Flather::compute_boundary_z_averages()
         m_yhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
     }
 
-    auto accumulate_boundary =
-        [&](const int lev,
-            const int idir,
-            const bool is_low,
-            MultiLevelVector& out_uvec,
-            MultiLevelVector& out_hvec,
-            const bool sample_boundary) {
-            auto& avg_h = out_uvec.host_data(lev);
-            auto& dist_h = out_hvec.host_data(lev);
-            const int nline = static_cast<int>(avg_h.size());
+    auto accumulate_boundary = [&](const int lev, const int idir,
+                                   const bool is_low,
+                                   MultiLevelVector& out_uvec,
+                                   MultiLevelVector& out_hvec,
+                                   const bool sample_boundary) {
+        auto& avg_h = out_uvec.host_data(lev);
+        auto& dist_h = out_hvec.host_data(lev);
+        const int nline = static_cast<int>(avg_h.size());
 
-            amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
-            amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
-            amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
-            amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
+        amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
+        amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
+        amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
+        amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
-            const auto& geom = m_mesh.Geom(lev);
-            const auto& dz = geom.CellSizeArray()[2];
-            const auto& dom = geom.Domain();
-            const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
-            const int off = dom.smallEnd(idir);
-            const int shift_to_boundary =
-                sample_boundary ? (is_low ? -1 : 1) : 0;
-            if (shift_to_boundary != 0) {
-                AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
-                AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
-            }
-            const amrex::Real vof_eps = amrex::max(0.0_rt, m_liquid_vof_eps);
+        const auto& geom = m_mesh.Geom(lev);
+        const auto& dz = geom.CellSizeArray()[2];
+        const auto& dom = geom.Domain();
+        const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
+        const int off = dom.smallEnd(idir);
+        const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
+        if (shift_to_boundary != 0) {
+            AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
+            AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
+        }
+        const amrex::Real tiny = constants::TIGHT_TOL;
 
-            const auto& vel_mf = m_velocity(lev);
+        const auto& vel_mf = m_velocity(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU());
-                 mfi.isValid(); ++mfi) {
-                amrex::Box bx = mfi.tilebox() & dom;
-                if (!bx.ok()) {
-                    continue;
-                }
-                if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
-                    continue;
-                }
-
-                bx.setSmall(idir, bidx);
-                bx.setBig(idir, bidx);
-
-                const auto vel_arr = vel_mf.const_array(mfi);
-                const auto vof_arr = m_vof(lev).const_array(mfi);
-                const bool use_terrain = (m_terrain_blank != nullptr);
-                const auto terrain_blank_arr =
-                    use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
-                                : amrex::Array4<int const>();
-
-                amrex::Real* uvof_sum = uvof_sum_d.data();
-                amrex::Real* vof_sum = vof_sum_d.data();
-
-                amrex::ParallelFor(
-                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                        const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
-                        const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
-
-                        if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
-                            return;
-                        }
-                        const int idx = (idir == 0) ? (i - off) : (j - off);
-                        const amrex::Real vf = amrex::max(
-                            0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
-                        amrex::Gpu::Atomic::Add(
-                            &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
-                        amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
-                    });
+        for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
+             ++mfi) {
+            amrex::Box bx = mfi.tilebox() & dom;
+            if (!bx.ok()) {
+                continue;
+            }
+            if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
+                continue;
             }
 
-            amrex::Gpu::copy(
-                amrex::Gpu::deviceToHost, uvof_sum_d.begin(),
-                uvof_sum_d.end(), uvof_sum_h.begin());
-            amrex::Gpu::copy(
-                amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
-                vof_sum_h.begin());
+            bx.setSmall(idir, bidx);
+            bx.setBig(idir, bidx);
 
-            amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
-            amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
+            const auto vel_arr = vel_mf.const_array(mfi);
+            const auto vof_arr = m_vof(lev).const_array(mfi);
+            const bool use_terrain = (m_terrain_blank != nullptr);
+            const auto terrain_blank_arr =
+                use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
+                            : amrex::Array4<int const>();
 
-            for (int n = 0; n < nline; ++n) {
-                avg_h[n] = (vof_sum_h[n] > vof_eps)
-                               ? (uvof_sum_h[n] / vof_sum_h[n])
-                               : 0.0_rt;
-                dist_h[n] = (vof_sum_h[n] > vof_eps)
-                               ? (vof_sum_h[n])
-                               : 0.0_rt;
-            }
-        };
+            amrex::Real* uvof_sum = uvof_sum_d.data();
+            amrex::Real* vof_sum = vof_sum_d.data();
+
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
+                const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
+
+                if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
+                    return;
+                }
+                const int idx = (idir == 0) ? (i - off) : (j - off);
+                const amrex::Real vf =
+                    amrex::max(0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
+                amrex::Gpu::Atomic::Add(
+                    &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
+                amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
+            });
+        }
+
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
+            uvof_sum_h.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
+            vof_sum_h.begin());
+
+        amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
+        amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
+
+        for (int n = 0; n < nline; ++n) {
+            avg_h[n] =
+                (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n]) : 0.0_rt;
+            dist_h[n] = vof_sum_h[n];
+        }
+    };
 
     for (int lev = 0; lev < nlevels; ++lev) {
         accumulate_boundary(lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false);
         accumulate_boundary(lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false);
         accumulate_boundary(lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
         accumulate_boundary(lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
-        accumulate_boundary(lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
-        accumulate_boundary(lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
-        accumulate_boundary(lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
-        accumulate_boundary(lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
+        accumulate_boundary(
+            lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
+        accumulate_boundary(
+            lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
+        accumulate_boundary(
+            lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
+        accumulate_boundary(
+            lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
     }
 
     m_xlo_uvof_avg.copy_host_to_device();
@@ -228,19 +199,13 @@ void Flather::set_velocity(
 {
     BL_PROFILE("kynema-sgf::Flather::set_velocity");
 
-    const amrex::Real relax = amrex::max(
-        0.0_rt, amrex::min<amrex::Real>(1.0_rt, m_relaxation));
-    const amrex::Real target_weight = amrex::max(
-        0.0_rt, amrex::min<amrex::Real>(1.0_rt, m_target_weight));
-
-    const amrex::Real tvx = m_uvec[0];
-    const amrex::Real tvy = m_uvec[1];
-    const amrex::Real tvz = m_uvec[2];
-
     const auto& geom = m_mesh.Geom(lev);
     const auto& bctype = fld.bc_type();
     const int nghost = 1;
     const auto& domain = geom.growPeriodicDomain(nghost);
+
+    const amrex::Real tiny = constants::TIGHT_TOL;
+    const auto grav_z = -m_gravity[2];
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         const auto ori = oit();
@@ -262,6 +227,10 @@ void Flather::set_velocity(
         const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
         const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
         const amrex::Real* yhi_uavg = m_yhi_uvof_avg.device_data(lev).data();
+        const amrex::Real* xlo_havg = m_xlo_h_avg.device_data(lev).data();
+        const amrex::Real* xhi_havg = m_xhi_h_avg.device_data(lev).data();
+        const amrex::Real* ylo_havg = m_ylo_h_avg.device_data(lev).data();
+        const amrex::Real* yhi_havg = m_yhi_h_avg.device_data(lev).data();
         const amrex::Real* xlo_bnd_uavg =
             m_xlo_bnd_uvof_avg.device_data(lev).data();
         const amrex::Real* xhi_bnd_uavg =
@@ -270,6 +239,14 @@ void Flather::set_velocity(
             m_ylo_bnd_uvof_avg.device_data(lev).data();
         const amrex::Real* yhi_bnd_uavg =
             m_yhi_bnd_uvof_avg.device_data(lev).data();
+        const amrex::Real* xlo_bnd_havg =
+            m_xlo_bnd_h_avg.device_data(lev).data();
+        const amrex::Real* xhi_bnd_havg =
+            m_xhi_bnd_h_avg.device_data(lev).data();
+        const amrex::Real* ylo_bnd_havg =
+            m_ylo_bnd_h_avg.device_data(lev).data();
+        const amrex::Real* yhi_bnd_havg =
+            m_yhi_bnd_h_avg.device_data(lev).data();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (false)
@@ -285,54 +262,72 @@ void Flather::set_velocity(
             const auto& arr = mfab[mfi].array();
             const int numcomp = mfab.nComp();
 
+            const auto vof_arr = m_vof(lev).const_array(mfi);
+            const bool use_terrain = (m_terrain_blank != nullptr);
+            const auto terrain_blank_arr =
+                use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
+                            : amrex::Array4<int const>();
+
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 const amrex::IntVect iv{i, j, k};
                 const amrex::IntVect iv_adj = iv + shift_to_interior;
-                const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> target_vel =
-                    {AMREX_D_DECL(tvx, tvy, tvz)};
 
                 for (int n = 0; n < numcomp; ++n) {
-                    amrex::Real boundary_old = arr(iv, dcomp + n);
+                    amrex::Real boundary_val = arr(iv, dcomp + n);
                     amrex::Real interior_val = arr(iv_adj, dcomp + n);
+                    amrex::Real boundary_h = 0.0_rt;
+                    amrex::Real interior_h = 0.0_rt;
                     if (use_x && (orig_comp + n == 0)) {
-                        interior_val = ori.isLow()
-                                           ? xlo_uavg[iv_adj[0] - xoff]
-                                           : xhi_uavg[iv_adj[0] - xoff];
-                        boundary_old = ori.isLow()
+                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[0] - xoff]
+                                                   : xhi_uavg[iv_adj[0] - xoff];
+                        interior_h = ori.isLow() ? xlo_havg[iv_adj[0] - xoff]
+                                                 : xhi_havg[iv_adj[0] - xoff];
+                        boundary_val = ori.isLow()
                                            ? xlo_bnd_uavg[iv_adj[0] - xoff]
                                            : xhi_bnd_uavg[iv_adj[0] - xoff];
+                        boundary_h = ori.isLow()
+                                         ? xlo_bnd_havg[iv_adj[0] - xoff]
+                                         : xhi_bnd_havg[iv_adj[0] - xoff];
                     } else if (use_y && (orig_comp + n == 1)) {
-                        interior_val = ori.isLow()
-                                           ? ylo_uavg[iv_adj[1] - yoff]
-                                           : yhi_uavg[iv_adj[1] - yoff];
-                        boundary_old = ori.isLow()
+                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[1] - yoff]
+                                                   : yhi_uavg[iv_adj[1] - yoff];
+                        interior_h = ori.isLow() ? ylo_havg[iv_adj[1] - yoff]
+                                                 : yhi_havg[iv_adj[1] - yoff];
+                        boundary_val = ori.isLow()
                                            ? ylo_bnd_uavg[iv_adj[1] - yoff]
                                            : yhi_bnd_uavg[iv_adj[1] - yoff];
+                        boundary_h = ori.isLow()
+                                         ? ylo_bnd_havg[iv_adj[1] - yoff]
+                                         : yhi_bnd_havg[iv_adj[1] - yoff];
                     }
-                    const amrex::Real target_val = target_vel[orig_comp + n];
 
-                    const amrex::Real desired =
-                        ((1.0_rt - target_weight) * interior_val) +
-                        (target_weight * target_val);
+                    // Set velocity to zero and skip for terrain
+                    if (use_terrain && terrain_blank_arr(iv) != 0) {
+                        arr(iv_adj, dcomp + n) = 0.0_rt;
+                        continue;
+                    }
+                    // Check interior or boundary vof for liquid
+                    const amrex::Real interior_vof = vof_arr(iv_adj);
+                    const amrex::Real boundary_vof = vof_arr(iv);
+                    // Do nothing here if not liquid
+                    if ((interior_vof < tiny) && (boundary_vof < tiny)) {
+                        continue;
+                    }
 
-                    arr(iv, dcomp + n) =
-                        ((1.0_rt - relax) * boundary_old) + (relax * desired);
+                    // Wave speed
+                    const amrex::Real c = std::sqrt(grav_z * interior_h);
+
+                    const auto Flather_val =
+                        boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
+                                           boundary_h *
+                                           (interior_h - boundary_h);
+
+                    arr(iv_adj, dcomp + n) =
+                        arr(iv, dcomp + n) * (Flather_val / interior_val);
                 }
             });
         }
     }
-}
-
-void Flather::update_target_velocity()
-{
-    const amrex::Real wind_speed = m_wind_speed;
-    const amrex::Real wind_direction = -m_wind_direction + 270.0_rt;
-    const amrex::Real wind_direction_radian =
-        kynema_sgf::utils::radians(wind_direction);
-
-    m_uvec[0] = wind_speed * std::cos(wind_direction_radian);
-    m_uvec[1] = wind_speed * std::sin(wind_direction_radian);
-    m_uvec[2] = 0.0_rt;
 }
 
 } // namespace kynema_sgf

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -69,7 +69,8 @@ void Flather::accumulate_boundary(
     const bool is_low,
     MultiLevelVector& out_uvec,
     MultiLevelVector& out_hvec,
-    const bool sample_boundary) const
+    const bool sample_boundary,
+    const FieldState fstate) const
 {
     AMREX_ALWAYS_ASSERT(idir == 0 || idir == 1);
 
@@ -110,7 +111,7 @@ void Flather::accumulate_boundary(
             AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
         }
 
-        const auto& vel_mf = m_velocity(lev);
+        const auto& vel_mf = m_velocity.state(fstate)(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -130,7 +131,7 @@ void Flather::accumulate_boundary(
             bx.setBig(idir, bidx);
 
             const auto vel_arr = vel_mf.const_array(mfi);
-            const auto vof_arr = m_vof(lev).const_array(mfi);
+            const auto vof_arr = m_vof.state(fstate)(lev).const_array(mfi);
             const auto mask_arr = level_mask.const_array(mfi);
             const bool use_terrain = (m_terrain_blank != nullptr);
             const auto terrain_blank_arr =
@@ -211,13 +212,13 @@ void Flather::compute_internal_z_averages()
 
     for (int lev = 0; lev < nlevels; ++lev) {
         this->accumulate_boundary(
-            lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false);
+            lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false);
+            lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
+            lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
+            lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false, FieldState::New);
     }
 
     m_xlo_uvof_avg.copy_host_to_device();
@@ -231,20 +232,21 @@ void Flather::compute_internal_z_averages()
     m_yhi_h_avg.copy_host_to_device();
 }
 
-void Flather::compute_boundary_z_averages(int lev)
+void Flather::compute_boundary_z_averages(
+    const int lev, const FieldState fstate)
 {
     BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
 
     // accumulating boundaries needs to happen prior to applying fillpatch op
 
     this->accumulate_boundary(
-        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
+        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true, fstate);
     this->accumulate_boundary(
-        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
+        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true, fstate);
     this->accumulate_boundary(
-        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
+        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true, fstate);
     this->accumulate_boundary(
-        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
+        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true, fstate);
 
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, m_xlo_bnd_uvof_avg.host_data(lev).begin(),
@@ -376,6 +378,7 @@ void Flather::set_velocity(
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 const amrex::IntVect iv{i, j, k};
+                // Need to account for shift to cell center, too!!
                 const amrex::IntVect iv_adj = iv + shift_to_interior;
 
                 amrex::Real boundary_val = arr(iv, fcomp);

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -388,8 +388,18 @@ void Flather::set_velocity(
                     boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
                                        boundary_h * (interior_h - boundary_h);
 
-                arr(iv, fcomp) =
+                const auto scaled_interior_vel =
                     arr(iv_adj, fcomp) * (Flather_val / interior_val);
+
+                // Only use if pointing outward or pulling liquid in
+                // Zero velocity is fine either way
+                const bool outflow = ori.isLow()
+                                         ? scaled_interior_vel <= 0.0_rt
+                                         : scaled_interior_vel >= 0.0_rt;
+                const bool inflow_liq = !outflow && boundary_vof >= tiny;
+                if (outflow || inflow_liq) {
+                    arr(iv, fcomp) = scaled_interior_vel;
+                }
             });
         }
     }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -465,11 +465,16 @@ void Flather::set_velocity(
                 const auto scaled_vel =
                     local_vel * (Flather_vel / averaged_vel);
 
-                // Only use if pointing outward or pulling liquid in (or zero)
+                // Only use if advecting liquid (or zero velocity)
+                // This is important because the averages used to calculate
+                // the Flather velocity are only performed on cells containing
+                // liquid; therefore, the scaling of the velocity is only valid
+                // on those cells.
                 const bool outflow =
                     ori.isLow() ? scaled_vel <= 0.0_rt : scaled_vel >= 0.0_rt;
-                const bool inflow_liq = !outflow && boundary_vof >= tiny;
-                if (outflow || inflow_liq) {
+                const bool inflow_liq = !outflow && boundary_vof > tiny;
+                const bool outflow_liq = outflow && interior_vof > tiny;
+                if (outflow_liq || inflow_liq) {
                     arr(iv, fcomp) = scaled_vel;
                 }
             });

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -104,7 +104,6 @@ void Flather::accumulate_boundary(
         const auto& dz = geom.CellSizeArray()[2];
         const auto& dom = geom.Domain();
         const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
-        const int off = dom.smallEnd(idir);
         const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
         if (shift_to_boundary != 0) {
             AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
@@ -149,7 +148,7 @@ void Flather::accumulate_boundary(
                     return;
                 }
                 // This index is tangent to the boundary
-                const int idx_lev = (idir == 0) ? (j - off) : (i - off);
+                const int idx_lev = (idir == 0) ? j : i;
                 // Convert to current level indices
                 const int idx_min =
                     idx_lev + idx_lev * (rr - 1) * (current_level - lev);
@@ -279,8 +278,6 @@ void Flather::set_velocity(
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
         const bool use_x = (idir == 0);
         const bool use_y = (idir == 1);
-        const int xoff = geom.Domain().smallEnd(0);
-        const int yoff = geom.Domain().smallEnd(1);
         const amrex::Real* xlo_uavg = m_xlo_uvof_avg.device_data(lev).data();
         const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
         const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
@@ -338,23 +335,23 @@ void Flather::set_velocity(
                     // Vectors at x boundaries extend in y direction
                     // Vectors at y boundaries extend in x direction
                     if (use_x && (orig_comp + n == 0)) {
-                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[1] - xoff]
-                                                   : xhi_uavg[iv_adj[1] - xoff];
-                        interior_h = ori.isLow() ? xlo_havg[iv_adj[1] - xoff]
-                                                 : xhi_havg[iv_adj[1] - xoff];
-                        boundary_val = ori.isLow() ? xlo_bnd_uavg[iv[1] - xoff]
-                                                   : xhi_bnd_uavg[iv[1] - xoff];
-                        boundary_h = ori.isLow() ? xlo_bnd_havg[iv[1] - xoff]
-                                                 : xhi_bnd_havg[iv[1] - xoff];
+                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[1]]
+                                                   : xhi_uavg[iv_adj[1]];
+                        interior_h = ori.isLow() ? xlo_havg[iv_adj[1]]
+                                                 : xhi_havg[iv_adj[1]];
+                        boundary_val = ori.isLow() ? xlo_bnd_uavg[iv[1]]
+                                                   : xhi_bnd_uavg[iv[1]];
+                        boundary_h = ori.isLow() ? xlo_bnd_havg[iv[1]]
+                                                 : xhi_bnd_havg[iv[1]];
                     } else if (use_y && (orig_comp + n == 1)) {
-                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[0] - yoff]
-                                                   : yhi_uavg[iv_adj[0] - yoff];
-                        interior_h = ori.isLow() ? ylo_havg[iv_adj[0] - yoff]
-                                                 : yhi_havg[iv_adj[0] - yoff];
-                        boundary_val = ori.isLow() ? ylo_bnd_uavg[iv[0] - yoff]
-                                                   : yhi_bnd_uavg[iv[0] - yoff];
-                        boundary_h = ori.isLow() ? ylo_bnd_havg[iv[0] - yoff]
-                                                 : yhi_bnd_havg[iv[0] - yoff];
+                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[0]]
+                                                   : yhi_uavg[iv_adj[0]];
+                        interior_h = ori.isLow() ? ylo_havg[iv_adj[0]]
+                                                 : yhi_havg[iv_adj[0]];
+                        boundary_val = ori.isLow() ? ylo_bnd_uavg[iv[0]]
+                                                   : yhi_bnd_uavg[iv[0]];
+                        boundary_h = ori.isLow() ? ylo_bnd_havg[iv[0]]
+                                                 : yhi_bnd_havg[iv[0]];
                     }
 
                     // Set velocity to zero and skip for terrain

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -517,6 +517,7 @@ void Flather::set_velocity(
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
+                    override_interior = (scale_interior > 10.0_rt);
                 } else {
                     override_interior = true;
                 }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -447,7 +447,7 @@ void Flather::set_velocity(
                 const amrex::IntVect iv_adj_cc = iv_adj + shift_to_cc;
 
                 amrex::Real boundary_val = arr(iv, fcomp);
-                amrex::Real interior_val = arr(iv_adj, fcomp);
+                amrex::Real interior_val = arr(iv_adj, fcomp); // Unused?
                 amrex::Real interior_liq = arr(iv_adj, fcomp);
                 amrex::Real interior_mix = arr(iv_adj, fcomp);
                 amrex::Real boundary_h = 0.0_rt;
@@ -530,6 +530,8 @@ void Flather::set_velocity(
                 // 3) If the boundary velocity is 0, then the scaling based on
                 //    external quantities is undefined. Keep the scale_interior
                 //    = 1
+                // 4) During initialization, the scaling can be very aggressive.
+                //    Limit how quickly things can change.
 
                 bool override_interior = false;
                 auto scale_interior = 1.0;
@@ -539,6 +541,10 @@ void Flather::set_velocity(
                 } else if (std::abs(boundary_val) > v_threshold * boundary_h) {
                     override_interior = true;
                 }
+
+                // Limit the scaling factor to prevent overly aggressive changes
+                scale_interior =
+                    amrex::max(0.5_rt, amrex::min(scale_interior, 1.2_rt));
 
                 auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -528,7 +528,7 @@ void Flather::set_velocity(
                 if (outflow_only_liq || inflow_any_liq) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
-                    arr(iv, fcomp) = arr(iv_adj, fcomp);
+                    arr(iv, fcomp) = local_vel;
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -35,7 +35,10 @@ Flather::Flather(CFDSim& sim)
         m_vof = &m_repo.get_field("vof");
     }
 
-    m_xline_uvof_avg.resize(0, m_mesh.Geom());
+    m_xlo_uvof_avg.resize(0, m_mesh.Geom());
+    m_xhi_uvof_avg.resize(0, m_mesh.Geom());
+    m_ylo_uvof_avg.resize(1, m_mesh.Geom());
+    m_yhi_uvof_avg.resize(1, m_mesh.Geom());
 
     update_target_velocity();
 }
@@ -43,7 +46,7 @@ Flather::Flather(CFDSim& sim)
 void Flather::post_init_actions()
 {
     m_velocity.register_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
-    compute_xlo_z_averages();
+    compute_boundary_z_averages();
 }
 
 void Flather::pre_advance_work()
@@ -54,7 +57,7 @@ void Flather::pre_advance_work()
         m_wind_direction =
             -m_sim.helics().m_inflow_wind_direction_to_kynema_sgf + 270.0_rt;
         update_target_velocity();
-        compute_xlo_z_averages();
+        compute_boundary_z_averages();
         return;
     }
 #endif
@@ -64,90 +67,111 @@ void Flather::pre_advance_work()
         m_wind_direction -= m_degrees_per_sec * m_time.delta_t();
     }
     update_target_velocity();
-    compute_xlo_z_averages();
+    compute_boundary_z_averages();
 }
 
-void Flather::compute_xlo_z_averages()
+void Flather::compute_boundary_z_averages()
 {
-    BL_PROFILE("kynema-sgf::Flather::compute_xlo_z_averages");
+    BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
 
     const int nlevels = m_repo.num_active_levels();
     const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
-    if (m_xline_uvof_avg.size() != nlevels_geom) {
-        m_xline_uvof_avg.resize(0, m_mesh.Geom());
+    if (m_xlo_uvof_avg.size() != nlevels_geom) {
+        m_xlo_uvof_avg.resize(0, m_mesh.Geom());
+        m_xhi_uvof_avg.resize(0, m_mesh.Geom());
+        m_ylo_uvof_avg.resize(1, m_mesh.Geom());
+        m_yhi_uvof_avg.resize(1, m_mesh.Geom());
     }
 
-    for (int lev = 0; lev < nlevels; ++lev) {
-        auto& uavg_h = m_xline_uvof_avg.host_data(lev);
-        const int nx = static_cast<int>(uavg_h.size());
+    auto accumulate_boundary =
+        [&](const int lev,
+            const int idir,
+            const bool is_low,
+            MultiLevelVector& out_vec) {
+            auto& avg_h = out_vec.host_data(lev);
+            const int nline = static_cast<int>(avg_h.size());
 
-        amrex::Vector<amrex::Real> uvof_sum_h(nx, 0.0_rt);
-        amrex::Vector<amrex::Real> vof_sum_h(nx, 0.0_rt);
-        amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nx, 0.0_rt);
-        amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nx, 0.0_rt);
+            amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
+            amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
+            amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
+            amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
-        const auto& geom = m_mesh.Geom(lev);
-        const auto& dom = geom.Domain();
-        const int ilo = dom.smallEnd(0);
-        const int xoff = ilo;
-        const amrex::Real vof_eps = amrex::max(0.0_rt, m_liquid_vof_eps);
+            const auto& geom = m_mesh.Geom(lev);
+            const auto& dom = geom.Domain();
+            const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
+            const int off = dom.smallEnd(idir);
+            const amrex::Real vof_eps = amrex::max(0.0_rt, m_liquid_vof_eps);
 
-        const auto& vel_mf = m_velocity(lev);
+            const auto& vel_mf = m_velocity(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-        for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
-             ++mfi) {
-            amrex::Box bx = mfi.tilebox() & dom;
-            if (!bx.ok()) {
-                continue;
+            for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                amrex::Box bx = mfi.tilebox() & dom;
+                if (!bx.ok()) {
+                    continue;
+                }
+                if (bidx < bx.smallEnd(idir) || bidx > bx.bigEnd(idir)) {
+                    continue;
+                }
+
+                bx.setSmall(idir, bidx);
+                bx.setBig(idir, bidx);
+
+                const auto vel_arr = vel_mf.const_array(mfi);
+                const bool include_vof = m_vof_exists;
+                const auto vof_arr =
+                    include_vof ? (*m_vof)(lev).const_array(mfi)
+                                : amrex::Array4<amrex::Real const>();
+
+                amrex::Real* uvof_sum = uvof_sum_d.data();
+                amrex::Real* vof_sum = vof_sum_d.data();
+
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        const int idx = (idir == 0) ? (i - off) : (j - off);
+                        const amrex::Real vf =
+                            include_vof
+                                ? amrex::max(
+                                      0.0_rt,
+                                      amrex::min(1.0_rt, vof_arr(i, j, k)))
+                                : 1.0_rt;
+                        amrex::Gpu::Atomic::Add(
+                            &uvof_sum[idx], vel_arr(i, j, k, idir) * vf);
+                        amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);
+                    });
             }
-            if (ilo < bx.smallEnd(0) || ilo > bx.bigEnd(0)) {
-                continue;
+
+            amrex::Gpu::copy(
+                amrex::Gpu::deviceToHost, uvof_sum_d.begin(),
+                uvof_sum_d.end(), uvof_sum_h.begin());
+            amrex::Gpu::copy(
+                amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
+                vof_sum_h.begin());
+
+            amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
+            amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
+
+            for (int n = 0; n < nline; ++n) {
+                avg_h[n] = (vof_sum_h[n] > vof_eps)
+                               ? (uvof_sum_h[n] / vof_sum_h[n])
+                               : 0.0_rt;
             }
+        };
 
-            bx.setSmall(0, ilo);
-            bx.setBig(0, ilo);
-
-            const auto vel_arr = vel_mf.const_array(mfi);
-            const bool include_vof = m_vof_exists;
-            const auto vof_arr =
-                include_vof ? (*m_vof)(lev).const_array(mfi)
-                            : amrex::Array4<amrex::Real const>();
-
-            amrex::Real* uvof_sum = uvof_sum_d.data();
-            amrex::Real* vof_sum = vof_sum_d.data();
-
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                const int idx = i - xoff;
-                const amrex::Real vf = include_vof
-                                           ? amrex::max(
-                                                 0.0_rt,
-                                                 amrex::min(1.0_rt, vof_arr(i, j, k)))
-                                           : 1.0_rt;
-                amrex::Gpu::Atomic::Add(&uvof_sum[idx], vel_arr(i, j, k, 0) * vf);
-                amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);
-            });
-        }
-
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
-            uvof_sum_h.begin());
-        amrex::Gpu::copy(
-            amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
-            vof_sum_h.begin());
-
-        amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nx);
-        amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nx);
-
-        for (int i = 0; i < nx; ++i) {
-            uavg_h[i] = (vof_sum_h[i] > vof_eps) ? (uvof_sum_h[i] / vof_sum_h[i])
-                                                 : 0.0_rt;
-        }
+    for (int lev = 0; lev < nlevels; ++lev) {
+        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg);
+        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg);
+        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg);
+        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg);
     }
 
-    m_xline_uvof_avg.copy_host_to_device();
+    m_xlo_uvof_avg.copy_host_to_device();
+    m_xhi_uvof_avg.copy_host_to_device();
+    m_ylo_uvof_avg.copy_host_to_device();
+    m_yhi_uvof_avg.copy_host_to_device();
 }
 
 void Flather::set_velocity(
@@ -186,9 +210,14 @@ void Flather::set_velocity(
                                       : amrex::adjCellHi(domain, idir, nghost);
         const auto shift_to_interior =
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
-        const bool is_xlo = (idir == 0) && ori.isLow();
-        const int ioff = geom.Domain().smallEnd(0);
-        const amrex::Real* xline_uavg = m_xline_uvof_avg.device_data(lev).data();
+        const bool use_x = (idir == 0);
+        const bool use_y = (idir == 1);
+        const int xoff = geom.Domain().smallEnd(0);
+        const int yoff = geom.Domain().smallEnd(1);
+        const amrex::Real* xlo_uavg = m_xlo_uvof_avg.device_data(lev).data();
+        const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
+        const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
+        const amrex::Real* yhi_uavg = m_yhi_uvof_avg.device_data(lev).data();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (false)
@@ -213,8 +242,14 @@ void Flather::set_velocity(
                 for (int n = 0; n < numcomp; ++n) {
                     const amrex::Real boundary_old = arr(iv, dcomp + n);
                     amrex::Real interior_val = arr(iv_adj, dcomp + n);
-                    if (is_xlo && (orig_comp + n == 0)) {
-                        interior_val = xline_uavg[iv_adj[0] - ioff];
+                    if (use_x && (orig_comp + n == 0)) {
+                        interior_val = ori.isLow()
+                                           ? xlo_uavg[iv_adj[0] - xoff]
+                                           : xhi_uavg[iv_adj[0] - xoff];
+                    } else if (use_y && (orig_comp + n == 1)) {
+                        interior_val = ori.isLow()
+                                           ? ylo_uavg[iv_adj[1] - yoff]
+                                           : yhi_uavg[iv_adj[1] - yoff];
                     }
                     const amrex::Real target_val = target_vel[orig_comp + n];
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -153,8 +153,12 @@ void Flather::accumulate_boundary(
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 const int ii = (idir == 0) ? (i + shift_to_boundary) : i;
                 const int jj = (idir == 1) ? (j + shift_to_boundary) : j;
-                const int ii_v = ii + static_cast<int>(idir == 0 && !is_low);
-                const int jj_v = jj + static_cast<int>(idir == 1 && !is_low);
+                const int ii_v =
+                    ii +
+                    static_cast<int>(use_mac_fields && idir == 0 && !is_low);
+                const int jj_v =
+                    jj +
+                    static_cast<int>(use_mac_fields && idir == 1 && !is_low);
 
                 if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
                     return;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -377,8 +377,9 @@ void Flather::set_velocity(
 #endif
         for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi) {
             auto gbx = amrex::grow(mfi.validbox(), nghost);
+            auto shift_to_cc = amrex::IntVect(0);
             const auto& bx =
-                utils::face_aware_boundary_box_intersection(gbx, dbx, ori);
+                utils::face_aware_boundary_box_intersection(shift_to_cc, gbx, dbx, ori);
             if (!bx.ok()) {
                 continue;
             }
@@ -394,8 +395,9 @@ void Flather::set_velocity(
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 const amrex::IntVect iv{i, j, k};
-                // Need to account for shift to cell center, too!!
+                const amrex::IntVect iv_cc = iv + shift_to_cc;
                 const amrex::IntVect iv_adj = iv + shift_to_interior;
+                const amrex::IntVect iv_adj_cc = iv_adj + shift_to_cc;
 
                 amrex::Real boundary_val = arr(iv, fcomp);
                 amrex::Real interior_val = arr(iv_adj, fcomp);
@@ -424,13 +426,13 @@ void Flather::set_velocity(
                 }
 
                 // Set velocity to zero and skip for terrain
-                if (use_terrain && terrain_blank_arr(iv_adj) != 0) {
+                if (use_terrain && terrain_blank_arr(iv_adj_cc) != 0) {
                     arr(iv, fcomp) = 0.0_rt;
                     return;
                 }
                 // Check interior or boundary vof for liquid
-                const amrex::Real interior_vof = vof_arr(iv_adj);
-                const amrex::Real boundary_vof = vof_arr(iv);
+                const amrex::Real interior_vof = vof_arr(iv_adj_cc);
+                const amrex::Real boundary_vof = vof_arr(iv_cc);
                 // Do nothing here if not liquid
                 if ((interior_vof < tiny) && (boundary_vof < tiny)) {
                     return;
@@ -444,7 +446,7 @@ void Flather::set_velocity(
                                        boundary_h * (interior_h - boundary_h);
 
                 const auto scaled_interior_vel =
-                    ref_arr(iv_adj, idir) * (Flather_val / interior_val);
+                    ref_arr(iv_adj_cc, idir) * (Flather_val / interior_val);
 
                 // Only use if pointing outward or pulling liquid in
                 // Zero velocity is fine either way

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -78,7 +78,6 @@ void Flather::accumulate_boundary(
     const int nline = static_cast<int>(avg_h.size());
 
     amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
-    amrex::Vector<amrex::Real> vof_sum_h(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
@@ -174,15 +173,14 @@ void Flather::accumulate_boundary(
         uvof_sum_h.begin());
     amrex::Gpu::copy(
         amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
-        vof_sum_h.begin());
+        dist_h.begin());
 
     amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
-    amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nline);
+    amrex::ParallelDescriptor::ReduceRealSum(dist_h.data(), nline);
 
     for (int n = 0; n < nline; ++n) {
         avg_h[n] =
-            (vof_sum_h[n] > tiny) ? (uvof_sum_h[n] / vof_sum_h[n]) : 0.0_rt;
-        dist_h[n] = vof_sum_h[n];
+            (dist_h[n] > tiny) ? (uvof_sum_h[n] / dist_h[n]) : 0.0_rt;
     }
 }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -136,8 +136,7 @@ void Flather::accumulate_boundary(
              ++mfi) {
             // Iterate in cell-centered index space, even for MAC fields, so
             // the box type matches the domain and the ii_v/jj_v face offsets
-            amrex::Box bx =
-                mfi.tilebox(amrex::IntVect::TheZeroVector()) & dom;
+            amrex::Box bx = mfi.tilebox(amrex::IntVect::TheZeroVector()) & dom;
             if (!bx.ok()) {
                 continue;
             }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -259,6 +259,7 @@ void Flather::set_velocity(
     const auto& geom = m_mesh.Geom(lev);
     const auto& bctype = fld.bc_type();
     const int nghost = 1;
+    const int numcomp = mfab.nComp();
     const auto& domain = geom.growPeriodicDomain(nghost);
 
     const amrex::Real tiny = constants::TIGHT_TOL;
@@ -272,12 +273,26 @@ void Flather::set_velocity(
         }
 
         const int idir = ori.coordDir();
+        // Check if orientation aligns with supplied field and choose component
+        bool skip_fill = false;
+        int fcomp = 0;
+        if (numcomp == 1) {
+            // MAC velocity: only normal field is valid
+            skip_fill = (orig_comp != idir);
+            // Only a single component available
+        } else {
+            // Cell-centered velocity: field always valid
+            fcomp = idir;
+            // Select valid component
+        }
+        if (skip_fill) {
+            continue;
+        }
+
         const auto& dbx = ori.isLow() ? amrex::adjCellLo(domain, idir, nghost)
                                       : amrex::adjCellHi(domain, idir, nghost);
         const auto shift_to_interior =
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
-        const bool use_x = (idir == 0);
-        const bool use_y = (idir == 1);
         const amrex::Real* xlo_uavg = m_xlo_uvof_avg.device_data(lev).data();
         const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
         const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
@@ -315,7 +330,6 @@ void Flather::set_velocity(
             }
 
             const auto& arr = mfab[mfi].array();
-            const int numcomp = mfab.nComp();
 
             const auto vof_arr = m_vof(lev).const_array(mfi);
             const bool use_terrain = (m_terrain_blank != nullptr);
@@ -327,57 +341,54 @@ void Flather::set_velocity(
                 const amrex::IntVect iv{i, j, k};
                 const amrex::IntVect iv_adj = iv + shift_to_interior;
 
-                for (int n = 0; n < numcomp; ++n) {
-                    amrex::Real boundary_val = arr(iv, dcomp + n);
-                    amrex::Real interior_val = arr(iv_adj, dcomp + n);
-                    amrex::Real boundary_h = 0.0_rt;
-                    amrex::Real interior_h = 0.0_rt;
-                    // Vectors at x boundaries extend in y direction
-                    // Vectors at y boundaries extend in x direction
-                    if (use_x && (orig_comp + n == 0)) {
-                        interior_val = ori.isLow() ? xlo_uavg[iv_adj[1]]
-                                                   : xhi_uavg[iv_adj[1]];
-                        interior_h = ori.isLow() ? xlo_havg[iv_adj[1]]
-                                                 : xhi_havg[iv_adj[1]];
-                        boundary_val = ori.isLow() ? xlo_bnd_uavg[iv[1]]
-                                                   : xhi_bnd_uavg[iv[1]];
-                        boundary_h = ori.isLow() ? xlo_bnd_havg[iv[1]]
-                                                 : xhi_bnd_havg[iv[1]];
-                    } else if (use_y && (orig_comp + n == 1)) {
-                        interior_val = ori.isLow() ? ylo_uavg[iv_adj[0]]
-                                                   : yhi_uavg[iv_adj[0]];
-                        interior_h = ori.isLow() ? ylo_havg[iv_adj[0]]
-                                                 : yhi_havg[iv_adj[0]];
-                        boundary_val = ori.isLow() ? ylo_bnd_uavg[iv[0]]
-                                                   : yhi_bnd_uavg[iv[0]];
-                        boundary_h = ori.isLow() ? ylo_bnd_havg[iv[0]]
-                                                 : yhi_bnd_havg[iv[0]];
-                    }
-
-                    // Set velocity to zero and skip for terrain
-                    if (use_terrain && terrain_blank_arr(iv_adj) != 0) {
-                        arr(iv, dcomp + n) = 0.0_rt;
-                        continue;
-                    }
-                    // Check interior or boundary vof for liquid
-                    const amrex::Real interior_vof = vof_arr(iv_adj);
-                    const amrex::Real boundary_vof = vof_arr(iv);
-                    // Do nothing here if not liquid
-                    if ((interior_vof < tiny) && (boundary_vof < tiny)) {
-                        continue;
-                    }
-
-                    // Wave speed
-                    const amrex::Real c = std::sqrt(grav_z * interior_h);
-
-                    const auto Flather_val =
-                        boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
-                                           boundary_h *
-                                           (interior_h - boundary_h);
-
-                    arr(iv, dcomp + n) =
-                        arr(iv_adj, dcomp + n) * (Flather_val / interior_val);
+                amrex::Real boundary_val = arr(iv, fcomp);
+                amrex::Real interior_val = arr(iv_adj, fcomp);
+                amrex::Real boundary_h = 0.0_rt;
+                amrex::Real interior_h = 0.0_rt;
+                // Vectors at x boundaries extend in y direction
+                // Vectors at y boundaries extend in x direction
+                if (idir == 0) {
+                    interior_val =
+                        ori.isLow() ? xlo_uavg[iv_adj[1]] : xhi_uavg[iv_adj[1]];
+                    interior_h =
+                        ori.isLow() ? xlo_havg[iv_adj[1]] : xhi_havg[iv_adj[1]];
+                    boundary_val =
+                        ori.isLow() ? xlo_bnd_uavg[iv[1]] : xhi_bnd_uavg[iv[1]];
+                    boundary_h =
+                        ori.isLow() ? xlo_bnd_havg[iv[1]] : xhi_bnd_havg[iv[1]];
+                } else {
+                    interior_val =
+                        ori.isLow() ? ylo_uavg[iv_adj[0]] : yhi_uavg[iv_adj[0]];
+                    interior_h =
+                        ori.isLow() ? ylo_havg[iv_adj[0]] : yhi_havg[iv_adj[0]];
+                    boundary_val =
+                        ori.isLow() ? ylo_bnd_uavg[iv[0]] : yhi_bnd_uavg[iv[0]];
+                    boundary_h =
+                        ori.isLow() ? ylo_bnd_havg[iv[0]] : yhi_bnd_havg[iv[0]];
                 }
+
+                // Set velocity to zero and skip for terrain
+                if (use_terrain && terrain_blank_arr(iv_adj) != 0) {
+                    arr(iv, fcomp) = 0.0_rt;
+                    return;
+                }
+                // Check interior or boundary vof for liquid
+                const amrex::Real interior_vof = vof_arr(iv_adj);
+                const amrex::Real boundary_vof = vof_arr(iv);
+                // Do nothing here if not liquid
+                if ((interior_vof < tiny) && (boundary_vof < tiny)) {
+                    return;
+                }
+
+                // Wave speed
+                const amrex::Real c = std::sqrt(grav_z * interior_h);
+
+                const auto Flather_val =
+                    boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
+                                       boundary_h * (interior_h - boundary_h);
+
+                arr(iv, fcomp) =
+                    arr(iv_adj, fcomp) * (Flather_val / interior_val);
             });
         }
     }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -34,6 +34,9 @@ Flather::Flather(CFDSim& sim)
     if (!m_repo.field_exists("vof")) {
         amrex::Abort("Flather BC requires the vof field");
     }
+    if (m_repo.int_field_exists("terrain_blank")) {
+        m_terrain_blank = &m_repo.get_int_field("terrain_blank");
+    }
 
     m_xlo_uvof_avg.resize(0, m_mesh.Geom());
     m_xhi_uvof_avg.resize(0, m_mesh.Geom());
@@ -122,12 +125,19 @@ void Flather::compute_boundary_z_averages()
 
                 const auto vel_arr = vel_mf.const_array(mfi);
                 const auto vof_arr = m_vof(lev).const_array(mfi);
+                const bool use_terrain = (m_terrain_blank != nullptr);
+                const auto terrain_blank_arr =
+                    use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
+                                : amrex::Array4<int const>();
 
                 amrex::Real* uvof_sum = uvof_sum_d.data();
                 amrex::Real* vof_sum = vof_sum_d.data();
 
                 amrex::ParallelFor(
                     bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        if (use_terrain && terrain_blank_arr(i, j, k) != 0) {
+                            return;
+                        }
                         const int idx = (idir == 0) ? (i - off) : (j - off);
                         const amrex::Real vf = amrex::max(
                             0.0_rt, amrex::min(1.0_rt, vof_arr(i, j, k)));

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -98,9 +98,11 @@ void Flather::compute_boundary_z_averages()
         [&](const int lev,
             const int idir,
             const bool is_low,
-            MultiLevelVector& out_vec,
+            MultiLevelVector& out_uvec,
+            MultiLevelVector& out_hvec,
             const bool sample_boundary) {
-            auto& avg_h = out_vec.host_data(lev);
+            auto& avg_h = out_uvec.host_data(lev);
+            auto& dist_h = out_hvec.host_data(lev);
             const int nline = static_cast<int>(avg_h.size());
 
             amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
@@ -109,6 +111,7 @@ void Flather::compute_boundary_z_averages()
             amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
             const auto& geom = m_mesh.Geom(lev);
+            const auto& dz = geom.CellSizeArray()[2];
             const auto& dom = geom.Domain();
             const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
             const int off = dom.smallEnd(idir);
@@ -160,8 +163,8 @@ void Flather::compute_boundary_z_averages()
                         const amrex::Real vf = amrex::max(
                             0.0_rt, amrex::min(1.0_rt, vof_arr(ii, jj, k)));
                         amrex::Gpu::Atomic::Add(
-                            &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf);
-                        amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);
+                            &uvof_sum[idx], vel_arr(ii, jj, k, idir) * vf * dz);
+                        amrex::Gpu::Atomic::Add(&vof_sum[idx], vf * dz);
                     });
             }
 
@@ -179,28 +182,40 @@ void Flather::compute_boundary_z_averages()
                 avg_h[n] = (vof_sum_h[n] > vof_eps)
                                ? (uvof_sum_h[n] / vof_sum_h[n])
                                : 0.0_rt;
+                dist_h[n] = (vof_sum_h[n] > vof_eps)
+                               ? (vof_sum_h[n])
+                               : 0.0_rt;
             }
         };
 
     for (int lev = 0; lev < nlevels; ++lev) {
-        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg, false);
-        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg, false);
-        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg, false);
-        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg, false);
-        accumulate_boundary(lev, 0, true, m_xlo_bnd_uvof_avg, true);
-        accumulate_boundary(lev, 0, false, m_xhi_bnd_uvof_avg, true);
-        accumulate_boundary(lev, 1, true, m_ylo_bnd_uvof_avg, true);
-        accumulate_boundary(lev, 1, false, m_yhi_bnd_uvof_avg, true);
+        accumulate_boundary(lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false);
+        accumulate_boundary(lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false);
+        accumulate_boundary(lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
+        accumulate_boundary(lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
+        accumulate_boundary(lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
+        accumulate_boundary(lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
+        accumulate_boundary(lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
+        accumulate_boundary(lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
     }
 
     m_xlo_uvof_avg.copy_host_to_device();
     m_xhi_uvof_avg.copy_host_to_device();
     m_ylo_uvof_avg.copy_host_to_device();
     m_yhi_uvof_avg.copy_host_to_device();
+    m_xlo_h_avg.copy_host_to_device();
+    m_xhi_h_avg.copy_host_to_device();
+    m_ylo_h_avg.copy_host_to_device();
+    m_yhi_h_avg.copy_host_to_device();
+
     m_xlo_bnd_uvof_avg.copy_host_to_device();
     m_xhi_bnd_uvof_avg.copy_host_to_device();
     m_ylo_bnd_uvof_avg.copy_host_to_device();
     m_yhi_bnd_uvof_avg.copy_host_to_device();
+    m_xlo_bnd_h_avg.copy_host_to_device();
+    m_xhi_bnd_h_avg.copy_host_to_device();
+    m_ylo_bnd_h_avg.copy_host_to_device();
+    m_yhi_bnd_h_avg.copy_host_to_device();
 }
 
 void Flather::set_velocity(

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -131,7 +131,10 @@ void Flather::accumulate_boundary(
             bx.setBig(idir, bidx);
 
             const auto vel_arr = vel_mf.const_array(mfi);
-            const auto vof_arr = m_vof.state(fstate)(lev).const_array(mfi);
+            // Due to the order that fillphysbc is called in prepare_boundaries
+            // (velocity, then scalars), the vof data is not available at
+            // alternate (nph) states when this is called.
+            const auto vof_arr = m_vof(lev).const_array(mfi);
             const auto mask_arr = level_mask.const_array(mfi);
             const bool use_terrain = (m_terrain_blank != nullptr);
             const auto terrain_blank_arr =

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -527,6 +527,8 @@ void Flather::set_velocity(
                     outflow && interior_vof < 1.0_rt - tiny;
                 if (outflow_only_liq || inflow_any_liq) {
                     arr(iv, fcomp) = scaled_vel;
+                } else if (outflow) {
+                    arr(iv, fcomp) = arr(iv_adj, fcomp);
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -196,10 +196,15 @@ void Flather::accumulate_boundary(
                         // Needs to be mixture to be counted
                         vel_height = 0.0_rt;
                     }
+                    amrex::Real local_vel =
+                        vel_arr(ii_v, jj_v, k, use_mac_fields ? 0 : idir);
+                    // If summing internal velocities, only allow outflow
+                    if (!sample_boundary) {
+                        local_vel = is_low ? amrex::min(local_vel, 0.0_rt)
+                                           : amrex::max(local_vel, 0.0_rt);
+                    }
                     amrex::Gpu::Atomic::Add(
-                        &uvof_sum[idx],
-                        vel_arr(ii_v, jj_v, k, use_mac_fields ? 0 : idir) *
-                            vel_height);
+                        &uvof_sum[idx], local_vel * vel_height);
                 }
             });
         }
@@ -499,9 +504,12 @@ void Flather::set_velocity(
                 const bool prescribed_inflow =
                     ori.isLow() ? boundary_val > 0.0_rt : boundary_val < 0.0_rt;
 
-                const auto local_vel = prescribed_inflow
-                                           ? arr(iv, fcomp)
-                                           : ref_arr(iv_adj_cc, idir);
+                const auto local_internal_vel =
+                    ori.isLow() ? amrex::min(ref_arr(iv_adj_cc, idir), 0.0_rt)
+                                : amrex::max(ref_arr(iv_adj_cc, idir), 0.0_rt);
+
+                const auto local_vel =
+                    prescribed_inflow ? arr(iv, fcomp) : local_internal_vel;
 
                 auto scaled_vel = 0.0_rt;
                 if (prescribed_inflow) {

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -192,10 +192,12 @@ void Flather::accumulate_boundary(
                         // Needs to be fully liquid to be counted
                         vel_height = 0.0_rt;
                     }
-                    if (phase_switch == 1 && vof_arr(ii, jj, k) > tiny) {
+                    if (phase_switch == 1 &&
+                        vof_arr(ii, jj, k) >= 1.0_rt - tiny) {
                         // Needs to be mixture to be counted
                         vel_height = 0.0_rt;
                     }
+                    // Fully gas cells never count because of vof multiplier
                     amrex::Real local_vel =
                         vel_arr(ii_v, jj_v, k, use_mac_fields ? 0 : idir);
                     // If summing internal velocities, only allow outflow

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -58,10 +58,10 @@ Flather::Flather(CFDSim& sim)
 void Flather::post_init_actions()
 {
     m_velocity.add_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
-    compute_boundary_z_averages();
+    compute_internal_z_averages();
 }
 
-void Flather::pre_advance_work() { compute_boundary_z_averages(); }
+void Flather::pre_advance_work() { compute_internal_z_averages(); }
 
 void Flather::accumulate_boundary(
     const int current_level,
@@ -183,9 +183,9 @@ void Flather::accumulate_boundary(
     }
 }
 
-void Flather::compute_boundary_z_averages()
+void Flather::compute_internal_z_averages()
 {
-    BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
+    BL_PROFILE("kynema-sgf::Flather::compute_internal_z_averages");
 
     const int nlevels = m_repo.num_active_levels();
     const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
@@ -218,33 +218,67 @@ void Flather::compute_boundary_z_averages()
             lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false);
         this->accumulate_boundary(
             lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false);
-        this->accumulate_boundary(
-            lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
-        this->accumulate_boundary(
-            lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
-        this->accumulate_boundary(
-            lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
-        this->accumulate_boundary(
-            lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
     }
 
     m_xlo_uvof_avg.copy_host_to_device();
     m_xhi_uvof_avg.copy_host_to_device();
     m_ylo_uvof_avg.copy_host_to_device();
     m_yhi_uvof_avg.copy_host_to_device();
-    m_xlo_bnd_uvof_avg.copy_host_to_device();
-    m_xhi_bnd_uvof_avg.copy_host_to_device();
-    m_ylo_bnd_uvof_avg.copy_host_to_device();
-    m_yhi_bnd_uvof_avg.copy_host_to_device();
 
     m_xlo_h_avg.copy_host_to_device();
     m_xhi_h_avg.copy_host_to_device();
     m_ylo_h_avg.copy_host_to_device();
     m_yhi_h_avg.copy_host_to_device();
-    m_xlo_bnd_h_avg.copy_host_to_device();
-    m_xhi_bnd_h_avg.copy_host_to_device();
-    m_ylo_bnd_h_avg.copy_host_to_device();
-    m_yhi_bnd_h_avg.copy_host_to_device();
+}
+
+void Flather::compute_boundary_z_averages(int lev)
+{
+    BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
+
+    // accumulating boundaries needs to happen prior to applying fillpatch op
+
+    this->accumulate_boundary(
+        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true);
+    this->accumulate_boundary(
+        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true);
+    this->accumulate_boundary(
+        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true);
+    this->accumulate_boundary(
+        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true);
+
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_xlo_bnd_uvof_avg.host_data(lev).begin(),
+        m_xlo_bnd_uvof_avg.host_data(lev).end(),
+        m_xlo_bnd_uvof_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_xhi_bnd_uvof_avg.host_data(lev).begin(),
+        m_xhi_bnd_uvof_avg.host_data(lev).end(),
+        m_xhi_bnd_uvof_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_ylo_bnd_uvof_avg.host_data(lev).begin(),
+        m_ylo_bnd_uvof_avg.host_data(lev).end(),
+        m_ylo_bnd_uvof_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_yhi_bnd_uvof_avg.host_data(lev).begin(),
+        m_yhi_bnd_uvof_avg.host_data(lev).end(),
+        m_yhi_bnd_uvof_avg.device_data(lev).begin());
+
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_xlo_bnd_h_avg.host_data(lev).begin(),
+        m_xlo_bnd_h_avg.host_data(lev).end(),
+        m_xlo_bnd_h_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_xhi_bnd_h_avg.host_data(lev).begin(),
+        m_xhi_bnd_h_avg.host_data(lev).end(),
+        m_xhi_bnd_h_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_ylo_bnd_h_avg.host_data(lev).begin(),
+        m_ylo_bnd_h_avg.host_data(lev).end(),
+        m_ylo_bnd_h_avg.device_data(lev).begin());
+    amrex::Gpu::copyAsync(
+        amrex::Gpu::hostToDevice, m_yhi_bnd_h_avg.host_data(lev).begin(),
+        m_yhi_bnd_h_avg.host_data(lev).end(),
+        m_yhi_bnd_h_avg.device_data(lev).begin());
 }
 
 void Flather::set_velocity(

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -363,8 +363,6 @@ void Flather::set_velocity(
     const amrex::Real tiny = constants::TIGHT_TOL;
     const amrex::Real v_threshold = 1.0e-6_rt;
     const auto grav_z = -m_gravity[2];
-    const auto rho1 = m_rho1;
-    const auto rho2 = m_rho2;
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         const auto ori = oit();
@@ -447,7 +445,6 @@ void Flather::set_velocity(
                 const amrex::IntVect iv_adj_cc = iv_adj + shift_to_cc;
 
                 amrex::Real boundary_val = arr(iv, fcomp);
-                amrex::Real interior_val = arr(iv_adj, fcomp); // Unused?
                 amrex::Real interior_liq = arr(iv_adj, fcomp);
                 amrex::Real interior_mix = arr(iv_adj, fcomp);
                 amrex::Real boundary_h = 0.0_rt;
@@ -459,7 +456,6 @@ void Flather::set_velocity(
                         ori.isLow() ? xlo_uliq[iv_adj[1]] : xhi_uliq[iv_adj[1]];
                     interior_mix =
                         ori.isLow() ? xlo_umix[iv_adj[1]] : xhi_umix[iv_adj[1]];
-                    interior_val = interior_liq + interior_mix;
                     interior_h =
                         ori.isLow() ? xlo_havg[iv_adj[1]] : xhi_havg[iv_adj[1]];
                     boundary_val =
@@ -471,7 +467,6 @@ void Flather::set_velocity(
                         ori.isLow() ? ylo_uliq[iv_adj[0]] : yhi_uliq[iv_adj[0]];
                     interior_mix =
                         ori.isLow() ? ylo_umix[iv_adj[0]] : yhi_umix[iv_adj[0]];
-                    interior_val = interior_liq + interior_mix;
                     interior_h =
                         ori.isLow() ? ylo_havg[iv_adj[0]] : yhi_havg[iv_adj[0]];
                     boundary_val =

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -57,7 +57,7 @@ Flather::Flather(CFDSim& sim)
 
 void Flather::post_init_actions()
 {
-    m_velocity.register_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
+    m_velocity.add_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
     compute_boundary_z_averages();
 }
 

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -2,6 +2,7 @@
 #include "src/boundary_conditions/field_boundary_fill/Flather.H"
 #include "src/boundary_conditions/field_boundary_fill/FillFlather.H"
 #include "src/utilities/index_operations.H"
+#include "AMReX_GpuAtomic.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_REAL.H"
 #include <algorithm>
@@ -27,6 +28,14 @@ Flather::Flather(CFDSim& sim)
     pp.query("start_time", m_start_time);
     pp.query("stop_time", m_stop_time);
     pp.query("degrees_per_second", m_degrees_per_sec);
+    pp.query("liquid_vof_eps", m_liquid_vof_eps);
+
+    m_vof_exists = m_repo.field_exists("vof");
+    if (m_vof_exists) {
+        m_vof = &m_repo.get_field("vof");
+    }
+
+    m_xline_uvof_avg.resize(0, m_mesh.Geom());
 
     update_target_velocity();
 }
@@ -34,6 +43,7 @@ Flather::Flather(CFDSim& sim)
 void Flather::post_init_actions()
 {
     m_velocity.register_fill_patch_op<FillFlather>(m_mesh, m_time, *this);
+    compute_xlo_z_averages();
 }
 
 void Flather::pre_advance_work()
@@ -44,6 +54,7 @@ void Flather::pre_advance_work()
         m_wind_direction =
             -m_sim.helics().m_inflow_wind_direction_to_kynema_sgf + 270.0_rt;
         update_target_velocity();
+        compute_xlo_z_averages();
         return;
     }
 #endif
@@ -53,6 +64,90 @@ void Flather::pre_advance_work()
         m_wind_direction -= m_degrees_per_sec * m_time.delta_t();
     }
     update_target_velocity();
+    compute_xlo_z_averages();
+}
+
+void Flather::compute_xlo_z_averages()
+{
+    BL_PROFILE("kynema-sgf::Flather::compute_xlo_z_averages");
+
+    const int nlevels = m_repo.num_active_levels();
+    const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
+    if (m_xline_uvof_avg.size() != nlevels_geom) {
+        m_xline_uvof_avg.resize(0, m_mesh.Geom());
+    }
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        auto& uavg_h = m_xline_uvof_avg.host_data(lev);
+        const int nx = static_cast<int>(uavg_h.size());
+
+        amrex::Vector<amrex::Real> uvof_sum_h(nx, 0.0_rt);
+        amrex::Vector<amrex::Real> vof_sum_h(nx, 0.0_rt);
+        amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nx, 0.0_rt);
+        amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nx, 0.0_rt);
+
+        const auto& geom = m_mesh.Geom(lev);
+        const auto& dom = geom.Domain();
+        const int ilo = dom.smallEnd(0);
+        const int xoff = ilo;
+        const amrex::Real vof_eps = amrex::max(0.0_rt, m_liquid_vof_eps);
+
+        const auto& vel_mf = m_velocity(lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(vel_mf, amrex::TilingIfNotGPU()); mfi.isValid();
+             ++mfi) {
+            amrex::Box bx = mfi.tilebox() & dom;
+            if (!bx.ok()) {
+                continue;
+            }
+            if (ilo < bx.smallEnd(0) || ilo > bx.bigEnd(0)) {
+                continue;
+            }
+
+            bx.setSmall(0, ilo);
+            bx.setBig(0, ilo);
+
+            const auto vel_arr = vel_mf.const_array(mfi);
+            const bool include_vof = m_vof_exists;
+            const auto vof_arr =
+                include_vof ? (*m_vof)(lev).const_array(mfi)
+                            : amrex::Array4<amrex::Real const>();
+
+            amrex::Real* uvof_sum = uvof_sum_d.data();
+            amrex::Real* vof_sum = vof_sum_d.data();
+
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                const int idx = i - xoff;
+                const amrex::Real vf = include_vof
+                                           ? amrex::max(
+                                                 0.0_rt,
+                                                 amrex::min(1.0_rt, vof_arr(i, j, k)))
+                                           : 1.0_rt;
+                amrex::Gpu::Atomic::Add(&uvof_sum[idx], vel_arr(i, j, k, 0) * vf);
+                amrex::Gpu::Atomic::Add(&vof_sum[idx], vf);
+            });
+        }
+
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
+            uvof_sum_h.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
+            vof_sum_h.begin());
+
+        amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nx);
+        amrex::ParallelDescriptor::ReduceRealSum(vof_sum_h.data(), nx);
+
+        for (int i = 0; i < nx; ++i) {
+            uavg_h[i] = (vof_sum_h[i] > vof_eps) ? (uvof_sum_h[i] / vof_sum_h[i])
+                                                 : 0.0_rt;
+        }
+    }
+
+    m_xline_uvof_avg.copy_host_to_device();
 }
 
 void Flather::set_velocity(
@@ -91,6 +186,9 @@ void Flather::set_velocity(
                                       : amrex::adjCellHi(domain, idir, nghost);
         const auto shift_to_interior =
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
+        const bool is_xlo = (idir == 0) && ori.isLow();
+        const int ioff = geom.Domain().smallEnd(0);
+        const amrex::Real* xline_uavg = m_xline_uvof_avg.device_data(lev).data();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (false)
@@ -114,7 +212,10 @@ void Flather::set_velocity(
 
                 for (int n = 0; n < numcomp; ++n) {
                     const amrex::Real boundary_old = arr(iv, dcomp + n);
-                    const amrex::Real interior_val = arr(iv_adj, dcomp + n);
+                    amrex::Real interior_val = arr(iv_adj, dcomp + n);
+                    if (is_xlo && (orig_comp + n == 0)) {
+                        interior_val = xline_uavg[iv_adj[0] - ioff];
+                    }
                     const amrex::Real target_val = target_vel[orig_comp + n];
 
                     const amrex::Real desired =

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -20,6 +20,8 @@ Flather::Flather(CFDSim& sim)
     , m_repo(m_sim.repo())
     , m_mesh(m_sim.mesh())
     , m_velocity(m_sim.repo().get_field("velocity"))
+    , m_u_mac(m_sim.repo().get_field("u_mac"))
+    , m_v_mac(m_sim.repo().get_field("v_mac"))
     , m_vof(m_sim.repo().get_field("vof"))
 {
     // amrex::ParmParse pp(identifier());
@@ -64,13 +66,14 @@ void Flather::post_init_actions()
 void Flather::pre_advance_work() { compute_internal_z_averages(); }
 
 void Flather::accumulate_boundary(
-    const int current_level,
-    const int idir,
-    const bool is_low,
+    int current_level,
+    int idir,
+    bool is_low,
     MultiLevelVector& out_uvec,
     MultiLevelVector& out_hvec,
-    const bool sample_boundary,
-    const FieldState fstate) const
+    bool sample_boundary,
+    FieldState fstate,
+    bool use_mac_fields) const
 {
     AMREX_ALWAYS_ASSERT(idir == 0 || idir == 1);
 
@@ -106,12 +109,14 @@ void Flather::accumulate_boundary(
         const auto& dom = geom.Domain();
         const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
         const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;
+        const auto& src_vel =
+            use_mac_fields ? ((idir == 0) ? m_u_mac : m_v_mac) : m_velocity;
         if (shift_to_boundary != 0) {
-            AMREX_ALWAYS_ASSERT(m_velocity.num_grow()[idir] > 0);
+            AMREX_ALWAYS_ASSERT(src_vel.num_grow()[idir] > 0);
             AMREX_ALWAYS_ASSERT(m_vof.num_grow()[idir] > 0);
         }
 
-        const auto& vel_mf = m_velocity.state(fstate)(lev);
+        const auto& vel_mf = src_vel.state(fstate)(lev);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -165,7 +170,8 @@ void Flather::accumulate_boundary(
                         vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
                     amrex::Gpu::Atomic::Add(
                         &uvof_sum[idx],
-                        vel_arr(ii, jj, k, idir) * liquid_height);
+                        vel_arr(ii, jj, k, use_mac_fields ? 0 : idir) *
+                            liquid_height);
                     amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
                 }
             });
@@ -236,20 +242,24 @@ void Flather::compute_internal_z_averages()
 }
 
 void Flather::compute_boundary_z_averages(
-    const int lev, const FieldState fstate)
+    int lev, FieldState fstate, bool use_mac_fields)
 {
     BL_PROFILE("kynema-sgf::Flather::compute_boundary_z_averages");
 
     // accumulating boundaries needs to happen prior to applying fillpatch op
 
     this->accumulate_boundary(
-        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true, fstate);
+        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true, fstate,
+        use_mac_fields);
     this->accumulate_boundary(
-        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true, fstate);
+        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true, fstate,
+        use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true, fstate);
+        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true, fstate,
+        use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true, fstate);
+        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true, fstate,
+        use_mac_fields);
 
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, m_xlo_bnd_uvof_avg.host_data(lev).begin(),

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -321,6 +321,7 @@ void Flather::set_velocity(
 
     const auto fstate = time > 0.0_rt ? FieldState::Old : FieldState::New;
     const amrex::Real tiny = constants::TIGHT_TOL;
+    const amrex::Real v_threshold = 1.0e-6_rt;
     const auto grav_z = -m_gravity[2];
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
@@ -463,7 +464,9 @@ void Flather::set_velocity(
                     prescribed_inflow ? boundary_val : interior_val;
 
                 const auto scaled_vel =
-                    local_vel * (Flather_vel / averaged_vel);
+                    std::abs(averaged_vel) > v_threshold
+                        ? local_vel * (Flather_vel / averaged_vel)
+                        : Flather_vel;
 
                 // Only use if advecting liquid (or zero velocity)
                 // This is important because the averages used to calculate

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -531,7 +531,9 @@ void Flather::set_velocity(
                 //    external quantities is undefined. Keep the scale_interior
                 //    = 1
                 // 4) During initialization, the scaling can be very aggressive.
-                //    Limit how quickly things can change.
+                //    Plus, when the internal and external profiles are very
+                //    different, the scaling can lead to rapid acceleration.
+                //    Switch to the external profile when the changes are rapid
 
                 bool override_interior = false;
                 auto scale_interior = 1.0;
@@ -542,9 +544,15 @@ void Flather::set_velocity(
                     override_interior = true;
                 }
 
+                if (scale_interior > 2.0_rt || scale_interior < 0.25_rt) {
+                    override_interior = true;
+                }
+
+                /*
                 // Limit the scaling factor to prevent overly aggressive changes
                 scale_interior =
                     amrex::max(0.5_rt, amrex::min(scale_interior, 1.2_rt));
+                */
 
                 auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -105,7 +105,7 @@ void Flather::accumulate_boundary(
         }
 
         const auto& geom = m_mesh.Geom(lev);
-        const auto& dz = geom.CellSizeArray()[2];
+        const auto dz = geom.CellSizeArray()[2];
         const auto& dom = geom.Domain();
         const int bidx = is_low ? dom.smallEnd(idir) : dom.bigEnd(idir);
         const int shift_to_boundary = sample_boundary ? (is_low ? -1 : 1) : 0;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -510,19 +510,23 @@ void Flather::set_velocity(
                     ori.isLow() ? amrex::min(ref_arr(iv_adj_cc, idir), 0.0_rt)
                                 : amrex::max(ref_arr(iv_adj_cc, idir), 0.0_rt);
 
-                const auto local_vel =
-                    prescribed_inflow ? arr(iv, fcomp) : local_internal_vel;
+                bool override_interior = false;
+                auto scale_interior = 1.0;
+                if (std::abs(interior_liq) > v_threshold * interior_h) {
+                    scale_interior =
+                        (Flather_val - interior_mix) / interior_liq;
+                } else {
+                    override_interior = true;
+                }
 
+                auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;
-                if (prescribed_inflow) {
+                if (prescribed_inflow || override_interior) {
+                    local_vel = arr(iv, fcomp);
                     scaled_vel = local_vel * (Flather_val / boundary_val);
                 } else {
-                    if (std::abs(interior_liq) > v_threshold * interior_h) {
-                        scaled_vel = local_vel * ((Flather_val - interior_mix) /
-                                                  interior_liq);
-                    } else {
-                        scaled_vel = Flather_val / interior_h;
-                    }
+                    local_vel = local_internal_vel;
+                    scaled_vel = local_vel * scale_interior;
                 }
 
                 // Only use if advecting liquid (or zero velocity)
@@ -536,8 +540,7 @@ void Flather::set_velocity(
                 const bool outflow_only_liq =
                     outflow && interior_vof < 1.0_rt - tiny;
                 if (outflow_only_liq || inflow_any_liq ||
-                    (outflow &&
-                     std::abs(interior_liq) <= v_threshold * interior_h)) {
+                    (outflow && override_interior)) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
                     arr(iv, fcomp) = local_vel;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -378,8 +378,8 @@ void Flather::set_velocity(
         for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi) {
             auto gbx = amrex::grow(mfi.validbox(), nghost);
             auto shift_to_cc = amrex::IntVect(0);
-            const auto& bx =
-                utils::face_aware_boundary_box_intersection(shift_to_cc, gbx, dbx, ori);
+            const auto& bx = utils::face_aware_boundary_box_intersection(
+                shift_to_cc, gbx, dbx, ori);
             if (!bx.ok()) {
                 continue;
             }
@@ -441,21 +441,32 @@ void Flather::set_velocity(
                 // Wave speed
                 const amrex::Real c = std::sqrt(grav_z * interior_h);
 
-                const auto Flather_val =
+                const auto Flather_vel =
                     boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
                                        boundary_h * (interior_h - boundary_h);
 
-                const auto scaled_interior_vel =
-                    ref_arr(iv_adj_cc, idir) * (Flather_val / interior_val);
+                // Use external (prescribed) velocity if inflow
+                // Assesses inflow by the whole column, not the local value
+                // Assumes values are up-to-date from another fillpatch op
+                const bool prescribed_inflow =
+                    ori.isLow() ? boundary_val > 0.0_rt : boundary_val < 0.0_rt;
 
-                // Only use if pointing outward or pulling liquid in
-                // Zero velocity is fine either way
-                const bool outflow = ori.isLow()
-                                         ? scaled_interior_vel <= 0.0_rt
-                                         : scaled_interior_vel >= 0.0_rt;
+                const auto local_vel = prescribed_inflow
+                                           ? arr(iv, fcomp)
+                                           : ref_arr(iv_adj_cc, idir);
+
+                const auto averaged_vel =
+                    prescribed_inflow ? boundary_val : interior_val;
+
+                const auto scaled_vel =
+                    local_vel * (Flather_vel / averaged_vel);
+
+                // Only use if pointing outward or pulling liquid in (or zero)
+                const bool outflow =
+                    ori.isLow() ? scaled_vel <= 0.0_rt : scaled_vel >= 0.0_rt;
                 const bool inflow_liq = !outflow && boundary_vof >= tiny;
                 if (outflow || inflow_liq) {
-                    arr(iv, fcomp) = scaled_interior_vel;
+                    arr(iv, fcomp) = scaled_vel;
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -44,14 +44,18 @@ Flather::Flather(CFDSim& sim)
 
     // Vector at the x boundary extends in y direction
     // Vector at the y boundary extends in x direction
-    m_xlo_uvof_avg.resize(1, m_mesh.Geom());
-    m_xhi_uvof_avg.resize(1, m_mesh.Geom());
-    m_ylo_uvof_avg.resize(0, m_mesh.Geom());
-    m_yhi_uvof_avg.resize(0, m_mesh.Geom());
-    m_xlo_bnd_uvof_avg.resize(1, m_mesh.Geom());
-    m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
-    m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
-    m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+    m_xlo_uliq.resize(1, m_mesh.Geom());
+    m_xhi_uliq.resize(1, m_mesh.Geom());
+    m_ylo_uliq.resize(0, m_mesh.Geom());
+    m_yhi_uliq.resize(0, m_mesh.Geom());
+    m_xlo_umix.resize(1, m_mesh.Geom());
+    m_xhi_umix.resize(1, m_mesh.Geom());
+    m_ylo_umix.resize(0, m_mesh.Geom());
+    m_yhi_umix.resize(0, m_mesh.Geom());
+    m_xlo_bnd_uvof.resize(1, m_mesh.Geom());
+    m_xhi_bnd_uvof.resize(1, m_mesh.Geom());
+    m_ylo_bnd_uvof.resize(0, m_mesh.Geom());
+    m_yhi_bnd_uvof.resize(0, m_mesh.Geom());
 
     m_xlo_h_avg.resize(1, m_mesh.Geom());
     m_xhi_h_avg.resize(1, m_mesh.Geom());
@@ -74,6 +78,7 @@ void Flather::pre_advance_work() { compute_internal_z_averages(); }
 void Flather::accumulate_boundary(
     int current_level,
     int idir,
+    int phase_switch,
     bool is_low,
     MultiLevelVector& out_uvec,
     MultiLevelVector& out_hvec,
@@ -83,11 +88,10 @@ void Flather::accumulate_boundary(
 {
     AMREX_ALWAYS_ASSERT(idir == 0 || idir == 1);
 
-    auto& avg_h = out_uvec.host_data(current_level);
+    auto& int_h = out_uvec.host_data(current_level);
     auto& dist_h = out_hvec.host_data(current_level);
-    const int nline = static_cast<int>(avg_h.size());
+    const int nline = static_cast<int>(int_h.size());
 
-    amrex::Vector<amrex::Real> uvof_sum_h(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
@@ -181,11 +185,21 @@ void Flather::accumulate_boundary(
                 for (int idx = idx_min; idx <= idx_max; ++idx) {
                     const auto liquid_height =
                         vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
+                    amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
+                    auto vel_height = liquid_height;
+                    if (phase_switch == 0 &&
+                        vof_arr(ii, jj, k) < 1.0_rt - tiny) {
+                        // Needs to be fully liquid to be counted
+                        vel_height = 0.0_rt;
+                    }
+                    if (phase_switch == 1 && vof_arr(ii, jj, k) > tiny) {
+                        // Needs to be mixture to be counted
+                        vel_height = 0.0_rt;
+                    }
                     amrex::Gpu::Atomic::Add(
                         &uvof_sum[idx],
                         vel_arr(ii_v, jj_v, k, use_mac_fields ? 0 : idir) *
-                            liquid_height);
-                    amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
+                            vel_height);
                 }
             });
         }
@@ -193,17 +207,13 @@ void Flather::accumulate_boundary(
 
     amrex::Gpu::copy(
         amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
-        uvof_sum_h.begin());
+        int_h.begin());
     amrex::Gpu::copy(
         amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
         dist_h.begin());
 
-    amrex::ParallelDescriptor::ReduceRealSum(uvof_sum_h.data(), nline);
+    amrex::ParallelDescriptor::ReduceRealSum(int_h.data(), nline);
     amrex::ParallelDescriptor::ReduceRealSum(dist_h.data(), nline);
-
-    for (int n = 0; n < nline; ++n) {
-        avg_h[n] = (dist_h[n] > tiny) ? (uvof_sum_h[n] / dist_h[n]) : 0.0_rt;
-    }
 }
 
 void Flather::compute_internal_z_averages()
@@ -212,15 +222,19 @@ void Flather::compute_internal_z_averages()
 
     const int nlevels = m_repo.num_active_levels();
     const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
-    if (m_xlo_uvof_avg.size() != nlevels_geom) {
-        m_xlo_uvof_avg.resize(1, m_mesh.Geom());
-        m_xhi_uvof_avg.resize(1, m_mesh.Geom());
-        m_ylo_uvof_avg.resize(0, m_mesh.Geom());
-        m_yhi_uvof_avg.resize(0, m_mesh.Geom());
-        m_xlo_bnd_uvof_avg.resize(1, m_mesh.Geom());
-        m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
-        m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
-        m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+    if (m_xlo_uliq.size() != nlevels_geom) {
+        m_xlo_uliq.resize(1, m_mesh.Geom());
+        m_xhi_uliq.resize(1, m_mesh.Geom());
+        m_ylo_uliq.resize(0, m_mesh.Geom());
+        m_yhi_uliq.resize(0, m_mesh.Geom());
+        m_xlo_umix.resize(1, m_mesh.Geom());
+        m_xhi_umix.resize(1, m_mesh.Geom());
+        m_ylo_umix.resize(0, m_mesh.Geom());
+        m_yhi_umix.resize(0, m_mesh.Geom());
+        m_xlo_bnd_uvof.resize(1, m_mesh.Geom());
+        m_xhi_bnd_uvof.resize(1, m_mesh.Geom());
+        m_ylo_bnd_uvof.resize(0, m_mesh.Geom());
+        m_yhi_bnd_uvof.resize(0, m_mesh.Geom());
 
         m_xlo_h_avg.resize(1, m_mesh.Geom());
         m_xhi_h_avg.resize(1, m_mesh.Geom());
@@ -234,19 +248,32 @@ void Flather::compute_internal_z_averages()
 
     for (int lev = 0; lev < nlevels; ++lev) {
         this->accumulate_boundary(
-            lev, 0, true, m_xlo_uvof_avg, m_xlo_h_avg, false, FieldState::New);
+            lev, 0, 0, true, m_xlo_uliq, m_xlo_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 0, false, m_xhi_uvof_avg, m_xhi_h_avg, false, FieldState::New);
+            lev, 0, 0, false, m_xhi_uliq, m_xhi_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, true, m_ylo_uvof_avg, m_ylo_h_avg, false, FieldState::New);
+            lev, 1, 0, true, m_ylo_uliq, m_ylo_h_avg, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, false, m_yhi_uvof_avg, m_yhi_h_avg, false, FieldState::New);
+            lev, 1, 0, false, m_yhi_uliq, m_yhi_h_avg, false, FieldState::New);
+        this->accumulate_boundary(
+            lev, 0, 1, true, m_xlo_umix, m_xlo_h_avg, false, FieldState::New);
+        this->accumulate_boundary(
+            lev, 0, 1, false, m_xhi_umix, m_xhi_h_avg, false, FieldState::New);
+        this->accumulate_boundary(
+            lev, 1, 1, true, m_ylo_umix, m_ylo_h_avg, false, FieldState::New);
+        this->accumulate_boundary(
+            lev, 1, 1, false, m_yhi_umix, m_yhi_h_avg, false, FieldState::New);
     }
 
-    m_xlo_uvof_avg.copy_host_to_device();
-    m_xhi_uvof_avg.copy_host_to_device();
-    m_ylo_uvof_avg.copy_host_to_device();
-    m_yhi_uvof_avg.copy_host_to_device();
+    m_xlo_uliq.copy_host_to_device();
+    m_xhi_uliq.copy_host_to_device();
+    m_ylo_uliq.copy_host_to_device();
+    m_yhi_uliq.copy_host_to_device();
+
+    m_xlo_umix.copy_host_to_device();
+    m_xhi_umix.copy_host_to_device();
+    m_ylo_umix.copy_host_to_device();
+    m_yhi_umix.copy_host_to_device();
 
     m_xlo_h_avg.copy_host_to_device();
     m_xhi_h_avg.copy_host_to_device();
@@ -262,34 +289,34 @@ void Flather::compute_boundary_z_averages(
     // accumulating boundaries needs to happen prior to applying fillpatch op
 
     this->accumulate_boundary(
-        lev, 0, true, m_xlo_bnd_uvof_avg, m_xlo_bnd_h_avg, true, fstate,
+        lev, 0, -1, true, m_xlo_bnd_uvof, m_xlo_bnd_h_avg, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 0, false, m_xhi_bnd_uvof_avg, m_xhi_bnd_h_avg, true, fstate,
+        lev, 0, -1, false, m_xhi_bnd_uvof, m_xhi_bnd_h_avg, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, true, m_ylo_bnd_uvof_avg, m_ylo_bnd_h_avg, true, fstate,
+        lev, 1, -1, true, m_ylo_bnd_uvof, m_ylo_bnd_h_avg, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, false, m_yhi_bnd_uvof_avg, m_yhi_bnd_h_avg, true, fstate,
+        lev, 1, -1, false, m_yhi_bnd_uvof, m_yhi_bnd_h_avg, true, fstate,
         use_mac_fields);
 
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xlo_bnd_uvof_avg.host_data(lev).begin(),
-        m_xlo_bnd_uvof_avg.host_data(lev).end(),
-        m_xlo_bnd_uvof_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xlo_bnd_uvof.host_data(lev).begin(),
+        m_xlo_bnd_uvof.host_data(lev).end(),
+        m_xlo_bnd_uvof.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xhi_bnd_uvof_avg.host_data(lev).begin(),
-        m_xhi_bnd_uvof_avg.host_data(lev).end(),
-        m_xhi_bnd_uvof_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xhi_bnd_uvof.host_data(lev).begin(),
+        m_xhi_bnd_uvof.host_data(lev).end(),
+        m_xhi_bnd_uvof.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_ylo_bnd_uvof_avg.host_data(lev).begin(),
-        m_ylo_bnd_uvof_avg.host_data(lev).end(),
-        m_ylo_bnd_uvof_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_ylo_bnd_uvof.host_data(lev).begin(),
+        m_ylo_bnd_uvof.host_data(lev).end(),
+        m_ylo_bnd_uvof.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_yhi_bnd_uvof_avg.host_data(lev).begin(),
-        m_yhi_bnd_uvof_avg.host_data(lev).end(),
-        m_yhi_bnd_uvof_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_yhi_bnd_uvof.host_data(lev).begin(),
+        m_yhi_bnd_uvof.host_data(lev).end(),
+        m_yhi_bnd_uvof.device_data(lev).begin());
 
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, m_xlo_bnd_h_avg.host_data(lev).begin(),
@@ -360,22 +387,22 @@ void Flather::set_velocity(
                                       : amrex::adjCellHi(domain, idir, nghost);
         const auto shift_to_interior =
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
-        const amrex::Real* xlo_uavg = m_xlo_uvof_avg.device_data(lev).data();
-        const amrex::Real* xhi_uavg = m_xhi_uvof_avg.device_data(lev).data();
-        const amrex::Real* ylo_uavg = m_ylo_uvof_avg.device_data(lev).data();
-        const amrex::Real* yhi_uavg = m_yhi_uvof_avg.device_data(lev).data();
+        const amrex::Real* xlo_uliq = m_xlo_uliq.device_data(lev).data();
+        const amrex::Real* xhi_uliq = m_xhi_uliq.device_data(lev).data();
+        const amrex::Real* ylo_uliq = m_ylo_uliq.device_data(lev).data();
+        const amrex::Real* yhi_uliq = m_yhi_uliq.device_data(lev).data();
+        const amrex::Real* xlo_umix = m_xlo_umix.device_data(lev).data();
+        const amrex::Real* xhi_umix = m_xhi_umix.device_data(lev).data();
+        const amrex::Real* ylo_umix = m_ylo_umix.device_data(lev).data();
+        const amrex::Real* yhi_umix = m_yhi_umix.device_data(lev).data();
         const amrex::Real* xlo_havg = m_xlo_h_avg.device_data(lev).data();
         const amrex::Real* xhi_havg = m_xhi_h_avg.device_data(lev).data();
         const amrex::Real* ylo_havg = m_ylo_h_avg.device_data(lev).data();
         const amrex::Real* yhi_havg = m_yhi_h_avg.device_data(lev).data();
-        const amrex::Real* xlo_bnd_uavg =
-            m_xlo_bnd_uvof_avg.device_data(lev).data();
-        const amrex::Real* xhi_bnd_uavg =
-            m_xhi_bnd_uvof_avg.device_data(lev).data();
-        const amrex::Real* ylo_bnd_uavg =
-            m_ylo_bnd_uvof_avg.device_data(lev).data();
-        const amrex::Real* yhi_bnd_uavg =
-            m_yhi_bnd_uvof_avg.device_data(lev).data();
+        const amrex::Real* xlo_bnd_u = m_xlo_bnd_uvof.device_data(lev).data();
+        const amrex::Real* xhi_bnd_u = m_xhi_bnd_uvof.device_data(lev).data();
+        const amrex::Real* ylo_bnd_u = m_ylo_bnd_uvof.device_data(lev).data();
+        const amrex::Real* yhi_bnd_u = m_yhi_bnd_uvof.device_data(lev).data();
         const amrex::Real* xlo_bnd_havg =
             m_xlo_bnd_h_avg.device_data(lev).data();
         const amrex::Real* xhi_bnd_havg =
@@ -414,26 +441,34 @@ void Flather::set_velocity(
 
                 amrex::Real boundary_val = arr(iv, fcomp);
                 amrex::Real interior_val = arr(iv_adj, fcomp);
+                amrex::Real interior_liq = arr(iv_adj, fcomp);
+                amrex::Real interior_mix = arr(iv_adj, fcomp);
                 amrex::Real boundary_h = 0.0_rt;
                 amrex::Real interior_h = 0.0_rt;
                 // Vectors at x boundaries extend in y direction
                 // Vectors at y boundaries extend in x direction
                 if (idir == 0) {
-                    interior_val =
-                        ori.isLow() ? xlo_uavg[iv_adj[1]] : xhi_uavg[iv_adj[1]];
+                    interior_liq =
+                        ori.isLow() ? xlo_uliq[iv_adj[1]] : xhi_uliq[iv_adj[1]];
+                    interior_mix =
+                        ori.isLow() ? xlo_umix[iv_adj[1]] : xhi_umix[iv_adj[1]];
+                    interior_val = interior_liq + interior_mix;
                     interior_h =
                         ori.isLow() ? xlo_havg[iv_adj[1]] : xhi_havg[iv_adj[1]];
                     boundary_val =
-                        ori.isLow() ? xlo_bnd_uavg[iv[1]] : xhi_bnd_uavg[iv[1]];
+                        ori.isLow() ? xlo_bnd_u[iv[1]] : xhi_bnd_u[iv[1]];
                     boundary_h =
                         ori.isLow() ? xlo_bnd_havg[iv[1]] : xhi_bnd_havg[iv[1]];
                 } else {
-                    interior_val =
-                        ori.isLow() ? ylo_uavg[iv_adj[0]] : yhi_uavg[iv_adj[0]];
+                    interior_liq =
+                        ori.isLow() ? ylo_uliq[iv_adj[0]] : yhi_uliq[iv_adj[0]];
+                    interior_mix =
+                        ori.isLow() ? ylo_umix[iv_adj[0]] : yhi_umix[iv_adj[0]];
+                    interior_val = interior_liq + interior_mix;
                     interior_h =
                         ori.isLow() ? ylo_havg[iv_adj[0]] : yhi_havg[iv_adj[0]];
                     boundary_val =
-                        ori.isLow() ? ylo_bnd_uavg[iv[0]] : yhi_bnd_uavg[iv[0]];
+                        ori.isLow() ? ylo_bnd_u[iv[0]] : yhi_bnd_u[iv[0]];
                     boundary_h =
                         ori.isLow() ? ylo_bnd_havg[iv[0]] : yhi_bnd_havg[iv[0]];
                 }
@@ -454,9 +489,9 @@ void Flather::set_velocity(
                 // Wave speed
                 const amrex::Real c = std::sqrt(grav_z * interior_h);
 
-                const auto Flather_vel =
-                    boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c /
-                                       boundary_h * (interior_h - boundary_h);
+                const auto Flather_val =
+                    boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
+                                       (interior_h - boundary_h);
 
                 // Use external (prescribed) velocity if inflow
                 // Assesses inflow by the whole column, not the local value
@@ -468,13 +503,17 @@ void Flather::set_velocity(
                                            ? arr(iv, fcomp)
                                            : ref_arr(iv_adj_cc, idir);
 
-                const auto averaged_vel =
-                    prescribed_inflow ? boundary_val : interior_val;
-
-                const auto scaled_vel =
-                    std::abs(averaged_vel) > v_threshold
-                        ? local_vel * (Flather_vel / averaged_vel)
-                        : Flather_vel;
+                auto scaled_vel = 0.0_rt;
+                if (prescribed_inflow) {
+                    scaled_vel = local_vel * (Flather_val / boundary_val);
+                } else {
+                    if (std::abs(interior_val) > v_threshold * interior_h) {
+                        scaled_vel = local_vel * ((Flather_val - interior_mix) /
+                                                  interior_liq);
+                    } else {
+                        scaled_vel = Flather_val / interior_h;
+                    }
+                }
 
                 // Only use if advecting liquid (or zero velocity)
                 // This is important because the averages used to calculate
@@ -483,17 +522,11 @@ void Flather::set_velocity(
                 // on those cells.
                 const bool outflow =
                     ori.isLow() ? scaled_vel <= 0.0_rt : scaled_vel >= 0.0_rt;
-                const bool inflow_liq = !outflow && boundary_vof > tiny;
-                const bool outflow_liq = outflow && interior_vof > tiny;
-                if (outflow_liq || inflow_liq) {
-                    const amrex::Real upstream_vof =
-                        outflow_liq ? interior_vof : boundary_vof;
-                    const amrex::Real upstream_density =
-                        upstream_vof * rho1 + (1.0_rt - upstream_vof) * rho2;
-                    arr(iv, fcomp) =
-                        (rho1 * upstream_vof * scaled_vel +
-                         rho2 * (1.0_rt - upstream_vof) * local_vel) /
-                        upstream_density;
+                const bool inflow_any_liq = !outflow && boundary_vof > tiny;
+                const bool outflow_only_liq =
+                    outflow && interior_vof < 1.0_rt - tiny;
+                if (outflow_only_liq || inflow_any_liq) {
+                    arr(iv, fcomp) = scaled_vel;
                 }
             });
         }

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -150,7 +150,7 @@ void Flather::accumulate_boundary(
                 for (int idx = idx_min;
                      idx <= amrex::max<int>(idx_min, idx_max); ++idx) {
                     const auto liquid_height =
-                        vof_arr(ii, jj, k) * dz * mask_arr(ii, jj, k);
+                        vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
                     amrex::Gpu::Atomic::Add(
                         &uvof_sum[idx],
                         vel_arr(ii, jj, k, idir) * liquid_height);

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -32,13 +32,15 @@ Flather::Flather(CFDSim& sim)
         m_terrain_blank = &m_repo.get_int_field("terrain_blank");
     }
 
-    if (m_sim.physics_manager().contains("MultiPhase")) {
-        m_rho1 = m_sim.physics_manager().get<kynema_sgf::MultiPhase>().rho1();
-        m_rho2 = m_sim.physics_manager().get<kynema_sgf::MultiPhase>().rho2();
+    {
+        amrex::ParmParse pp(identifier());
+        pp.query("max_velocity_scale_factor", m_velocity_scale_factor_max);
+        pp.query("min_velocity_scale_factor", m_velocity_scale_factor_min);
     }
-
-    amrex::ParmParse pp("incflo");
-    pp.queryarr("gravity", m_gravity);
+    {
+        amrex::ParmParse pp("incflo");
+        pp.queryarr("gravity", m_gravity);
+    }
 
     // Vector at the x boundary extends in y direction
     // Vector at the y boundary extends in x direction
@@ -361,6 +363,8 @@ void Flather::set_velocity(
     const amrex::Real tiny = constants::TIGHT_TOL;
     const amrex::Real v_threshold = 1.0e-6_rt;
     const auto grav_z = -m_gravity[2];
+    const auto vscale_min = m_velocity_scale_factor_min;
+    const auto vscale_max = m_velocity_scale_factor_max;
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         const auto ori = oit();
@@ -512,33 +516,35 @@ void Flather::set_velocity(
                 //    unchanged.
 
                 // Edge cases:
-                // 1) If the boundary contains no liquid, the Flather velocity
-                //    can be very large. Use a regular outflow (Neumann)
-                //    condition.
-
+                // 1) If the boundary velocity is 0, then the scaling based on
+                //    external quantities is undefined. Keep scale_interior = 1.
                 // 2) If the interior column contains no fully liquid cells,
                 //    there is nothing to scale. Instead of scaling the internal
                 //    profile, override the interior velocity with scaled
                 //    external profile.
-
-                // 3) If the boundary velocity is 0, then the scaling based on
-                //    external quantities is undefined. Keep scale_interior = 1.
-
-                // 4) During initialization, the scaling can be very aggressive.
+                // 3) During initialization, the scaling can be very aggressive.
                 //    Plus, when the internal and external profiles are very
                 //    different, the scaling can lead to rapid acceleration.
                 //    Switch to the external profile when the changes are rapid.
+                // 4) If the boundary contains no liquid, the Flather velocity
+                //    can be very large. Use a regular outflow (Neumann)
+                //    condition.
 
                 bool override_interior = false;
+                // Edge case 1 (when both conditions are false)
                 auto scale_interior = 1.0_rt;
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
+                    // Normal case
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
                 } else if (std::abs(boundary_val) > v_threshold * boundary_h) {
+                    // Edge case 2
                     override_interior = true;
                 }
 
-                if (scale_interior > 2.0_rt || scale_interior < 0.25_rt) {
+                if (scale_interior > vscale_max ||
+                    scale_interior < vscale_min) {
+                    // Edge case 3
                     override_interior = true;
                 }
 
@@ -553,10 +559,9 @@ void Flather::set_velocity(
                 }
 
                 // Only use if advecting liquid (or zero velocity):
-                // This is important because the averages used to calculate
-                // the Flather velocity are only performed on cells containing
-                // liquid; therefore, the scaling of the velocity is only valid
-                // on those cells.
+                // The averages used to calculate the Flather velocity are only
+                // performed on cells containing liquid; therefore, the scaling
+                // of the velocity is only valid on those cells.
                 const bool outflow =
                     ori.isLow() ? scaled_vel <= 0.0_rt : scaled_vel >= 0.0_rt;
                 const bool inflow_any_liq = !outflow && boundary_vof > tiny;
@@ -566,6 +571,7 @@ void Flather::set_velocity(
                                           (outflow && override_interior))) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
+                    // Edge case 4 (boundary_h <= tiny)
                     arr(iv, fcomp) = local_vel;
                 }
             });

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -185,7 +185,10 @@ void Flather::accumulate_boundary(
                 for (int idx = idx_min; idx <= idx_max; ++idx) {
                     const auto liquid_height =
                         vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
-                    amrex::Gpu::Atomic::Add(&vof_sum[idx], liquid_height);
+                    // Threads share these sums, so the atomic must be
+                    // host-safe as well as device-safe
+                    amrex::HostDevice::Atomic::Add(
+                        &vof_sum[idx], liquid_height);
                     auto vel_height = liquid_height;
                     if (phase_switch == 0 &&
                         vof_arr(ii, jj, k) < 1.0_rt - tiny) {
@@ -205,7 +208,7 @@ void Flather::accumulate_boundary(
                         local_vel = is_low ? amrex::min(local_vel, 0.0_rt)
                                            : amrex::max(local_vel, 0.0_rt);
                     }
-                    amrex::Gpu::Atomic::Add(
+                    amrex::HostDevice::Atomic::Add(
                         &uh_sum[idx], local_vel * vel_height);
                 }
             });

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -44,27 +44,27 @@ Flather::Flather(CFDSim& sim)
 
     // Vector at the x boundary extends in y direction
     // Vector at the y boundary extends in x direction
-    m_xlo_uliq.resize(1, m_mesh.Geom());
-    m_xhi_uliq.resize(1, m_mesh.Geom());
-    m_ylo_uliq.resize(0, m_mesh.Geom());
-    m_yhi_uliq.resize(0, m_mesh.Geom());
-    m_xlo_umix.resize(1, m_mesh.Geom());
-    m_xhi_umix.resize(1, m_mesh.Geom());
-    m_ylo_umix.resize(0, m_mesh.Geom());
-    m_yhi_umix.resize(0, m_mesh.Geom());
-    m_xlo_bnd_uvof.resize(1, m_mesh.Geom());
-    m_xhi_bnd_uvof.resize(1, m_mesh.Geom());
-    m_ylo_bnd_uvof.resize(0, m_mesh.Geom());
-    m_yhi_bnd_uvof.resize(0, m_mesh.Geom());
+    m_xlo_uhliq.resize(1, m_mesh.Geom());
+    m_xhi_uhliq.resize(1, m_mesh.Geom());
+    m_ylo_uhliq.resize(0, m_mesh.Geom());
+    m_yhi_uhliq.resize(0, m_mesh.Geom());
+    m_xlo_uhmix.resize(1, m_mesh.Geom());
+    m_xhi_uhmix.resize(1, m_mesh.Geom());
+    m_ylo_uhmix.resize(0, m_mesh.Geom());
+    m_yhi_uhmix.resize(0, m_mesh.Geom());
+    m_xlo_bnd_uh.resize(1, m_mesh.Geom());
+    m_xhi_bnd_uh.resize(1, m_mesh.Geom());
+    m_ylo_bnd_uh.resize(0, m_mesh.Geom());
+    m_yhi_bnd_uh.resize(0, m_mesh.Geom());
 
-    m_xlo_h_avg.resize(1, m_mesh.Geom());
-    m_xhi_h_avg.resize(1, m_mesh.Geom());
-    m_ylo_h_avg.resize(0, m_mesh.Geom());
-    m_yhi_h_avg.resize(0, m_mesh.Geom());
-    m_xlo_bnd_h_avg.resize(1, m_mesh.Geom());
-    m_xhi_bnd_h_avg.resize(1, m_mesh.Geom());
-    m_ylo_bnd_h_avg.resize(0, m_mesh.Geom());
-    m_yhi_bnd_h_avg.resize(0, m_mesh.Geom());
+    m_xlo_h.resize(1, m_mesh.Geom());
+    m_xhi_h.resize(1, m_mesh.Geom());
+    m_ylo_h.resize(0, m_mesh.Geom());
+    m_yhi_h.resize(0, m_mesh.Geom());
+    m_xlo_bnd_h.resize(1, m_mesh.Geom());
+    m_xhi_bnd_h.resize(1, m_mesh.Geom());
+    m_ylo_bnd_h.resize(0, m_mesh.Geom());
+    m_yhi_bnd_h.resize(0, m_mesh.Geom());
 }
 
 void Flather::post_init_actions()
@@ -92,7 +92,7 @@ void Flather::accumulate_boundary(
     auto& dist_h = out_hvec.host_data(current_level);
     const int nline = static_cast<int>(int_h.size());
 
-    amrex::Gpu::DeviceVector<amrex::Real> uvof_sum_d(nline, 0.0_rt);
+    amrex::Gpu::DeviceVector<amrex::Real> uh_sum_d(nline, 0.0_rt);
     amrex::Gpu::DeviceVector<amrex::Real> vof_sum_d(nline, 0.0_rt);
 
     const amrex::Real tiny = constants::TIGHT_TOL;
@@ -157,7 +157,7 @@ void Flather::accumulate_boundary(
                 use_terrain ? (*m_terrain_blank)(lev).const_array(mfi)
                             : amrex::Array4<int const>();
 
-            amrex::Real* uvof_sum = uvof_sum_d.data();
+            amrex::Real* uh_sum = uh_sum_d.data();
             amrex::Real* vof_sum = vof_sum_d.data();
 
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
@@ -206,14 +206,14 @@ void Flather::accumulate_boundary(
                                            : amrex::max(local_vel, 0.0_rt);
                     }
                     amrex::Gpu::Atomic::Add(
-                        &uvof_sum[idx], local_vel * vel_height);
+                        &uh_sum[idx], local_vel * vel_height);
                 }
             });
         }
     }
 
     amrex::Gpu::copy(
-        amrex::Gpu::deviceToHost, uvof_sum_d.begin(), uvof_sum_d.end(),
+        amrex::Gpu::deviceToHost, uh_sum_d.begin(), uh_sum_d.end(),
         int_h.begin());
     amrex::Gpu::copy(
         amrex::Gpu::deviceToHost, vof_sum_d.begin(), vof_sum_d.end(),
@@ -229,63 +229,63 @@ void Flather::compute_internal_z_averages()
 
     const int nlevels = m_repo.num_active_levels();
     const int nlevels_geom = static_cast<int>(m_mesh.Geom().size());
-    if (m_xlo_uliq.size() != nlevels_geom) {
-        m_xlo_uliq.resize(1, m_mesh.Geom());
-        m_xhi_uliq.resize(1, m_mesh.Geom());
-        m_ylo_uliq.resize(0, m_mesh.Geom());
-        m_yhi_uliq.resize(0, m_mesh.Geom());
-        m_xlo_umix.resize(1, m_mesh.Geom());
-        m_xhi_umix.resize(1, m_mesh.Geom());
-        m_ylo_umix.resize(0, m_mesh.Geom());
-        m_yhi_umix.resize(0, m_mesh.Geom());
-        m_xlo_bnd_uvof.resize(1, m_mesh.Geom());
-        m_xhi_bnd_uvof.resize(1, m_mesh.Geom());
-        m_ylo_bnd_uvof.resize(0, m_mesh.Geom());
-        m_yhi_bnd_uvof.resize(0, m_mesh.Geom());
+    if (m_xlo_uhliq.size() != nlevels_geom) {
+        m_xlo_uhliq.resize(1, m_mesh.Geom());
+        m_xhi_uhliq.resize(1, m_mesh.Geom());
+        m_ylo_uhliq.resize(0, m_mesh.Geom());
+        m_yhi_uhliq.resize(0, m_mesh.Geom());
+        m_xlo_uhmix.resize(1, m_mesh.Geom());
+        m_xhi_uhmix.resize(1, m_mesh.Geom());
+        m_ylo_uhmix.resize(0, m_mesh.Geom());
+        m_yhi_uhmix.resize(0, m_mesh.Geom());
+        m_xlo_bnd_uh.resize(1, m_mesh.Geom());
+        m_xhi_bnd_uh.resize(1, m_mesh.Geom());
+        m_ylo_bnd_uh.resize(0, m_mesh.Geom());
+        m_yhi_bnd_uh.resize(0, m_mesh.Geom());
 
-        m_xlo_h_avg.resize(1, m_mesh.Geom());
-        m_xhi_h_avg.resize(1, m_mesh.Geom());
-        m_ylo_h_avg.resize(0, m_mesh.Geom());
-        m_yhi_h_avg.resize(0, m_mesh.Geom());
-        m_xlo_bnd_h_avg.resize(1, m_mesh.Geom());
-        m_xhi_bnd_h_avg.resize(1, m_mesh.Geom());
-        m_ylo_bnd_h_avg.resize(0, m_mesh.Geom());
-        m_yhi_bnd_h_avg.resize(0, m_mesh.Geom());
+        m_xlo_h.resize(1, m_mesh.Geom());
+        m_xhi_h.resize(1, m_mesh.Geom());
+        m_ylo_h.resize(0, m_mesh.Geom());
+        m_yhi_h.resize(0, m_mesh.Geom());
+        m_xlo_bnd_h.resize(1, m_mesh.Geom());
+        m_xhi_bnd_h.resize(1, m_mesh.Geom());
+        m_ylo_bnd_h.resize(0, m_mesh.Geom());
+        m_yhi_bnd_h.resize(0, m_mesh.Geom());
     }
 
     for (int lev = 0; lev < nlevels; ++lev) {
         this->accumulate_boundary(
-            lev, 0, 0, true, m_xlo_uliq, m_xlo_h_avg, false, FieldState::New);
+            lev, 0, 0, true, m_xlo_uhliq, m_xlo_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 0, 0, false, m_xhi_uliq, m_xhi_h_avg, false, FieldState::New);
+            lev, 0, 0, false, m_xhi_uhliq, m_xhi_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, 0, true, m_ylo_uliq, m_ylo_h_avg, false, FieldState::New);
+            lev, 1, 0, true, m_ylo_uhliq, m_ylo_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, 0, false, m_yhi_uliq, m_yhi_h_avg, false, FieldState::New);
+            lev, 1, 0, false, m_yhi_uhliq, m_yhi_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 0, 1, true, m_xlo_umix, m_xlo_h_avg, false, FieldState::New);
+            lev, 0, 1, true, m_xlo_uhmix, m_xlo_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 0, 1, false, m_xhi_umix, m_xhi_h_avg, false, FieldState::New);
+            lev, 0, 1, false, m_xhi_uhmix, m_xhi_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, 1, true, m_ylo_umix, m_ylo_h_avg, false, FieldState::New);
+            lev, 1, 1, true, m_ylo_uhmix, m_ylo_h, false, FieldState::New);
         this->accumulate_boundary(
-            lev, 1, 1, false, m_yhi_umix, m_yhi_h_avg, false, FieldState::New);
+            lev, 1, 1, false, m_yhi_uhmix, m_yhi_h, false, FieldState::New);
     }
 
-    m_xlo_uliq.copy_host_to_device();
-    m_xhi_uliq.copy_host_to_device();
-    m_ylo_uliq.copy_host_to_device();
-    m_yhi_uliq.copy_host_to_device();
+    m_xlo_uhliq.copy_host_to_device();
+    m_xhi_uhliq.copy_host_to_device();
+    m_ylo_uhliq.copy_host_to_device();
+    m_yhi_uhliq.copy_host_to_device();
 
-    m_xlo_umix.copy_host_to_device();
-    m_xhi_umix.copy_host_to_device();
-    m_ylo_umix.copy_host_to_device();
-    m_yhi_umix.copy_host_to_device();
+    m_xlo_uhmix.copy_host_to_device();
+    m_xhi_uhmix.copy_host_to_device();
+    m_ylo_uhmix.copy_host_to_device();
+    m_yhi_uhmix.copy_host_to_device();
 
-    m_xlo_h_avg.copy_host_to_device();
-    m_xhi_h_avg.copy_host_to_device();
-    m_ylo_h_avg.copy_host_to_device();
-    m_yhi_h_avg.copy_host_to_device();
+    m_xlo_h.copy_host_to_device();
+    m_xhi_h.copy_host_to_device();
+    m_ylo_h.copy_host_to_device();
+    m_yhi_h.copy_host_to_device();
 }
 
 void Flather::compute_boundary_z_averages(
@@ -296,51 +296,47 @@ void Flather::compute_boundary_z_averages(
     // accumulating boundaries needs to happen prior to applying fillpatch op
 
     this->accumulate_boundary(
-        lev, 0, -1, true, m_xlo_bnd_uvof, m_xlo_bnd_h_avg, true, fstate,
+        lev, 0, -1, true, m_xlo_bnd_uh, m_xlo_bnd_h, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 0, -1, false, m_xhi_bnd_uvof, m_xhi_bnd_h_avg, true, fstate,
+        lev, 0, -1, false, m_xhi_bnd_uh, m_xhi_bnd_h, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, -1, true, m_ylo_bnd_uvof, m_ylo_bnd_h_avg, true, fstate,
+        lev, 1, -1, true, m_ylo_bnd_uh, m_ylo_bnd_h, true, fstate,
         use_mac_fields);
     this->accumulate_boundary(
-        lev, 1, -1, false, m_yhi_bnd_uvof, m_yhi_bnd_h_avg, true, fstate,
+        lev, 1, -1, false, m_yhi_bnd_uh, m_yhi_bnd_h, true, fstate,
         use_mac_fields);
 
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xlo_bnd_uvof.host_data(lev).begin(),
-        m_xlo_bnd_uvof.host_data(lev).end(),
-        m_xlo_bnd_uvof.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xlo_bnd_uh.host_data(lev).begin(),
+        m_xlo_bnd_uh.host_data(lev).end(),
+        m_xlo_bnd_uh.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xhi_bnd_uvof.host_data(lev).begin(),
-        m_xhi_bnd_uvof.host_data(lev).end(),
-        m_xhi_bnd_uvof.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xhi_bnd_uh.host_data(lev).begin(),
+        m_xhi_bnd_uh.host_data(lev).end(),
+        m_xhi_bnd_uh.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_ylo_bnd_uvof.host_data(lev).begin(),
-        m_ylo_bnd_uvof.host_data(lev).end(),
-        m_ylo_bnd_uvof.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_ylo_bnd_uh.host_data(lev).begin(),
+        m_ylo_bnd_uh.host_data(lev).end(),
+        m_ylo_bnd_uh.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_yhi_bnd_uvof.host_data(lev).begin(),
-        m_yhi_bnd_uvof.host_data(lev).end(),
-        m_yhi_bnd_uvof.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_yhi_bnd_uh.host_data(lev).begin(),
+        m_yhi_bnd_uh.host_data(lev).end(),
+        m_yhi_bnd_uh.device_data(lev).begin());
 
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xlo_bnd_h_avg.host_data(lev).begin(),
-        m_xlo_bnd_h_avg.host_data(lev).end(),
-        m_xlo_bnd_h_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xlo_bnd_h.host_data(lev).begin(),
+        m_xlo_bnd_h.host_data(lev).end(), m_xlo_bnd_h.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_xhi_bnd_h_avg.host_data(lev).begin(),
-        m_xhi_bnd_h_avg.host_data(lev).end(),
-        m_xhi_bnd_h_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_xhi_bnd_h.host_data(lev).begin(),
+        m_xhi_bnd_h.host_data(lev).end(), m_xhi_bnd_h.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_ylo_bnd_h_avg.host_data(lev).begin(),
-        m_ylo_bnd_h_avg.host_data(lev).end(),
-        m_ylo_bnd_h_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_ylo_bnd_h.host_data(lev).begin(),
+        m_ylo_bnd_h.host_data(lev).end(), m_ylo_bnd_h.device_data(lev).begin());
     amrex::Gpu::copyAsync(
-        amrex::Gpu::hostToDevice, m_yhi_bnd_h_avg.host_data(lev).begin(),
-        m_yhi_bnd_h_avg.host_data(lev).end(),
-        m_yhi_bnd_h_avg.device_data(lev).begin());
+        amrex::Gpu::hostToDevice, m_yhi_bnd_h.host_data(lev).begin(),
+        m_yhi_bnd_h.host_data(lev).end(), m_yhi_bnd_h.device_data(lev).begin());
 }
 
 void Flather::set_velocity(
@@ -394,30 +390,26 @@ void Flather::set_velocity(
                                       : amrex::adjCellHi(domain, idir, nghost);
         const auto shift_to_interior =
             amrex::IntVect::TheDimensionVector(idir) * (ori.isLow() ? 1 : -1);
-        const amrex::Real* xlo_uliq = m_xlo_uliq.device_data(lev).data();
-        const amrex::Real* xhi_uliq = m_xhi_uliq.device_data(lev).data();
-        const amrex::Real* ylo_uliq = m_ylo_uliq.device_data(lev).data();
-        const amrex::Real* yhi_uliq = m_yhi_uliq.device_data(lev).data();
-        const amrex::Real* xlo_umix = m_xlo_umix.device_data(lev).data();
-        const amrex::Real* xhi_umix = m_xhi_umix.device_data(lev).data();
-        const amrex::Real* ylo_umix = m_ylo_umix.device_data(lev).data();
-        const amrex::Real* yhi_umix = m_yhi_umix.device_data(lev).data();
-        const amrex::Real* xlo_havg = m_xlo_h_avg.device_data(lev).data();
-        const amrex::Real* xhi_havg = m_xhi_h_avg.device_data(lev).data();
-        const amrex::Real* ylo_havg = m_ylo_h_avg.device_data(lev).data();
-        const amrex::Real* yhi_havg = m_yhi_h_avg.device_data(lev).data();
-        const amrex::Real* xlo_bnd_u = m_xlo_bnd_uvof.device_data(lev).data();
-        const amrex::Real* xhi_bnd_u = m_xhi_bnd_uvof.device_data(lev).data();
-        const amrex::Real* ylo_bnd_u = m_ylo_bnd_uvof.device_data(lev).data();
-        const amrex::Real* yhi_bnd_u = m_yhi_bnd_uvof.device_data(lev).data();
-        const amrex::Real* xlo_bnd_havg =
-            m_xlo_bnd_h_avg.device_data(lev).data();
-        const amrex::Real* xhi_bnd_havg =
-            m_xhi_bnd_h_avg.device_data(lev).data();
-        const amrex::Real* ylo_bnd_havg =
-            m_ylo_bnd_h_avg.device_data(lev).data();
-        const amrex::Real* yhi_bnd_havg =
-            m_yhi_bnd_h_avg.device_data(lev).data();
+        const amrex::Real* xlo_uhliq = m_xlo_uhliq.device_data(lev).data();
+        const amrex::Real* xhi_uhliq = m_xhi_uhliq.device_data(lev).data();
+        const amrex::Real* ylo_uhliq = m_ylo_uhliq.device_data(lev).data();
+        const amrex::Real* yhi_uhliq = m_yhi_uhliq.device_data(lev).data();
+        const amrex::Real* xlo_uhmix = m_xlo_uhmix.device_data(lev).data();
+        const amrex::Real* xhi_uhmix = m_xhi_uhmix.device_data(lev).data();
+        const amrex::Real* ylo_uhmix = m_ylo_uhmix.device_data(lev).data();
+        const amrex::Real* yhi_uhmix = m_yhi_uhmix.device_data(lev).data();
+        const amrex::Real* xlo_h = m_xlo_h.device_data(lev).data();
+        const amrex::Real* xhi_h = m_xhi_h.device_data(lev).data();
+        const amrex::Real* ylo_h = m_ylo_h.device_data(lev).data();
+        const amrex::Real* yhi_h = m_yhi_h.device_data(lev).data();
+        const amrex::Real* xlo_bnd_uh = m_xlo_bnd_uh.device_data(lev).data();
+        const amrex::Real* xhi_bnd_uh = m_xhi_bnd_uh.device_data(lev).data();
+        const amrex::Real* ylo_bnd_uh = m_ylo_bnd_uh.device_data(lev).data();
+        const amrex::Real* yhi_bnd_uh = m_yhi_bnd_uh.device_data(lev).data();
+        const amrex::Real* xlo_bnd_h = m_xlo_bnd_h.device_data(lev).data();
+        const amrex::Real* xhi_bnd_h = m_xhi_bnd_h.device_data(lev).data();
+        const amrex::Real* ylo_bnd_h = m_ylo_bnd_h.device_data(lev).data();
+        const amrex::Real* yhi_bnd_h = m_yhi_bnd_h.device_data(lev).data();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (false)
@@ -454,27 +446,27 @@ void Flather::set_velocity(
                 // Vectors at x boundaries extend in y direction
                 // Vectors at y boundaries extend in x direction
                 if (idir == 0) {
-                    interior_liq =
-                        ori.isLow() ? xlo_uliq[iv_adj[1]] : xhi_uliq[iv_adj[1]];
-                    interior_mix =
-                        ori.isLow() ? xlo_umix[iv_adj[1]] : xhi_umix[iv_adj[1]];
+                    interior_liq = ori.isLow() ? xlo_uhliq[iv_adj[1]]
+                                               : xhi_uhliq[iv_adj[1]];
+                    interior_mix = ori.isLow() ? xlo_uhmix[iv_adj[1]]
+                                               : xhi_uhmix[iv_adj[1]];
                     interior_h =
-                        ori.isLow() ? xlo_havg[iv_adj[1]] : xhi_havg[iv_adj[1]];
+                        ori.isLow() ? xlo_h[iv_adj[1]] : xhi_h[iv_adj[1]];
                     boundary_val =
-                        ori.isLow() ? xlo_bnd_u[iv[1]] : xhi_bnd_u[iv[1]];
+                        ori.isLow() ? xlo_bnd_uh[iv[1]] : xhi_bnd_uh[iv[1]];
                     boundary_h =
-                        ori.isLow() ? xlo_bnd_havg[iv[1]] : xhi_bnd_havg[iv[1]];
+                        ori.isLow() ? xlo_bnd_h[iv[1]] : xhi_bnd_h[iv[1]];
                 } else {
-                    interior_liq =
-                        ori.isLow() ? ylo_uliq[iv_adj[0]] : yhi_uliq[iv_adj[0]];
-                    interior_mix =
-                        ori.isLow() ? ylo_umix[iv_adj[0]] : yhi_umix[iv_adj[0]];
+                    interior_liq = ori.isLow() ? ylo_uhliq[iv_adj[0]]
+                                               : yhi_uhliq[iv_adj[0]];
+                    interior_mix = ori.isLow() ? ylo_uhmix[iv_adj[0]]
+                                               : yhi_uhmix[iv_adj[0]];
                     interior_h =
-                        ori.isLow() ? ylo_havg[iv_adj[0]] : yhi_havg[iv_adj[0]];
+                        ori.isLow() ? ylo_h[iv_adj[0]] : yhi_h[iv_adj[0]];
                     boundary_val =
-                        ori.isLow() ? ylo_bnd_u[iv[0]] : yhi_bnd_u[iv[0]];
+                        ori.isLow() ? ylo_bnd_uh[iv[0]] : yhi_bnd_uh[iv[0]];
                     boundary_h =
-                        ori.isLow() ? ylo_bnd_havg[iv[0]] : yhi_bnd_havg[iv[0]];
+                        ori.isLow() ? ylo_bnd_h[iv[0]] : yhi_bnd_h[iv[0]];
                 }
 
                 // Set velocity to zero and skip for terrain
@@ -493,6 +485,7 @@ void Flather::set_velocity(
                 // Wave speed
                 const amrex::Real c = std::sqrt(grav_z * interior_h);
 
+                // Calculation of Flather formula. "val" = velocity * h
                 const auto Flather_val =
                     boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
                                        (interior_h - boundary_h);
@@ -550,6 +543,7 @@ void Flather::set_velocity(
 
                 auto local_vel = 0.0_rt;
                 auto scaled_vel = 0.0_rt;
+                // Apply scale to velocity, depends on direction
                 if (prescribed_inflow || override_interior) {
                     local_vel = arr(iv, fcomp);
                     scaled_vel = local_vel * (Flather_val / boundary_val);

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -308,7 +308,7 @@ void Flather::set_velocity(
     const amrex::Real time,
     const Field& fld,
     amrex::MultiFab& mfab,
-    const int dcomp,
+    const int /* dcomp */,
     const int orig_comp) const
 {
     BL_PROFILE("kynema-sgf::Flather::set_velocity");

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -531,7 +531,7 @@ void Flather::set_velocity(
                 //    Switch to the external profile when the changes are rapid
 
                 bool override_interior = false;
-                auto scale_interior = 1.0;
+                auto scale_interior = 1.0_rt;
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -152,10 +152,11 @@ void Flather::accumulate_boundary(
                 // Convert to current level indices
                 const int idx_min =
                     idx_lev + idx_lev * (rr - 1) * (current_level - lev);
-                const int idx_max = idx_min + rr * (current_level - lev) - 1;
+                const int idx_max =
+                    idx_min +
+                    amrex::max<int>(0, rr * (current_level - lev) - 1);
 
-                for (int idx = idx_min;
-                     idx <= amrex::max<int>(idx_min, idx_max); ++idx) {
+                for (int idx = idx_min; idx <= idx_max; ++idx) {
                     const auto liquid_height =
                         vof_arr(ii, jj, k) * dz * mask_arr(i, j, k);
                     amrex::Gpu::Atomic::Add(

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -497,10 +497,8 @@ void Flather::set_velocity(
                 const amrex::Real c = std::sqrt(grav_z * interior_h);
 
                 const auto Flather_val =
-                    boundary_h > tiny
-                        ? boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
-                                             (interior_h - boundary_h)
-                        : 0.0_rt;
+                    boundary_val + (ori.isLow() ? -1.0_rt : 1.0_rt) * c *
+                                       (interior_h - boundary_h);
 
                 // Use external (prescribed) velocity if inflow
                 // Assesses inflow by the whole column, not the local value
@@ -517,7 +515,6 @@ void Flather::set_velocity(
                 if (std::abs(interior_liq) > v_threshold * interior_h) {
                     scale_interior =
                         (Flather_val - interior_mix) / interior_liq;
-                    override_interior = (scale_interior > 10.0_rt);
                 } else {
                     override_interior = true;
                 }
@@ -542,8 +539,8 @@ void Flather::set_velocity(
                 const bool inflow_any_liq = !outflow && boundary_vof > tiny;
                 const bool outflow_only_liq =
                     outflow && interior_vof < 1.0_rt - tiny;
-                if (outflow_only_liq || inflow_any_liq ||
-                    (outflow && override_interior)) {
+                if (boundary_h > tiny && (outflow_only_liq || inflow_any_liq ||
+                                          (outflow && override_interior))) {
                     arr(iv, fcomp) = scaled_vel;
                 } else if (outflow) {
                     arr(iv, fcomp) = local_vel;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -44,6 +44,15 @@ Flather::Flather(CFDSim& sim)
     m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
     m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
     m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+
+    m_xlo_h_avg.resize(1, m_mesh.Geom());
+    m_xhi_h_avg.resize(1, m_mesh.Geom());
+    m_ylo_h_avg.resize(0, m_mesh.Geom());
+    m_yhi_h_avg.resize(0, m_mesh.Geom());
+    m_xlo_bnd_h_avg.resize(1, m_mesh.Geom());
+    m_xhi_bnd_h_avg.resize(1, m_mesh.Geom());
+    m_ylo_bnd_h_avg.resize(0, m_mesh.Geom());
+    m_yhi_bnd_h_avg.resize(0, m_mesh.Geom());
 }
 
 void Flather::post_init_actions()
@@ -192,6 +201,15 @@ void Flather::compute_boundary_z_averages()
         m_xhi_bnd_uvof_avg.resize(1, m_mesh.Geom());
         m_ylo_bnd_uvof_avg.resize(0, m_mesh.Geom());
         m_yhi_bnd_uvof_avg.resize(0, m_mesh.Geom());
+
+        m_xlo_h_avg.resize(1, m_mesh.Geom());
+        m_xhi_h_avg.resize(1, m_mesh.Geom());
+        m_ylo_h_avg.resize(0, m_mesh.Geom());
+        m_yhi_h_avg.resize(0, m_mesh.Geom());
+        m_xlo_bnd_h_avg.resize(1, m_mesh.Geom());
+        m_xhi_bnd_h_avg.resize(1, m_mesh.Geom());
+        m_ylo_bnd_h_avg.resize(0, m_mesh.Geom());
+        m_yhi_bnd_h_avg.resize(0, m_mesh.Geom());
     }
 
     for (int lev = 0; lev < nlevels; ++lev) {
@@ -217,15 +235,15 @@ void Flather::compute_boundary_z_averages()
     m_xhi_uvof_avg.copy_host_to_device();
     m_ylo_uvof_avg.copy_host_to_device();
     m_yhi_uvof_avg.copy_host_to_device();
-    m_xlo_h_avg.copy_host_to_device();
-    m_xhi_h_avg.copy_host_to_device();
-    m_ylo_h_avg.copy_host_to_device();
-    m_yhi_h_avg.copy_host_to_device();
-
     m_xlo_bnd_uvof_avg.copy_host_to_device();
     m_xhi_bnd_uvof_avg.copy_host_to_device();
     m_ylo_bnd_uvof_avg.copy_host_to_device();
     m_yhi_bnd_uvof_avg.copy_host_to_device();
+
+    m_xlo_h_avg.copy_host_to_device();
+    m_xhi_h_avg.copy_host_to_device();
+    m_ylo_h_avg.copy_host_to_device();
+    m_yhi_h_avg.copy_host_to_device();
     m_xlo_bnd_h_avg.copy_host_to_device();
     m_xhi_bnd_h_avg.copy_host_to_device();
     m_ylo_bnd_h_avg.copy_host_to_device();

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -577,7 +577,7 @@ void Flather::set_velocity(
                     ori.isLow() ? scaled_vel <= 0.0_rt : scaled_vel >= 0.0_rt;
                 const bool inflow_any_liq = !outflow && boundary_vof > tiny;
                 const bool outflow_only_liq =
-                    outflow && interior_vof < 1.0_rt - tiny;
+                    outflow && interior_vof >= 1.0_rt - tiny;
                 if (boundary_h > tiny && (outflow_only_liq || inflow_any_liq ||
                                           (outflow && override_interior))) {
                     arr(iv, fcomp) = scaled_vel;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -100,7 +100,12 @@ void Flather::accumulate_boundary(
     // Loop through current level and all below
     for (int lev = current_level; lev >= 0; --lev) {
 
-        const auto rr = m_mesh.refRatio(lev)[1 - idir];
+        // Cumulative refinement ratio, tangent to the boundary, between this
+        // level and the current level
+        int rr = 1;
+        for (int flev = lev; flev < current_level; ++flev) {
+            rr *= m_mesh.refRatio(flev)[1 - idir];
+        }
 
         amrex::iMultiFab level_mask;
         if (lev < current_level) {
@@ -178,11 +183,8 @@ void Flather::accumulate_boundary(
                 // This index is tangent to the boundary
                 const int idx_lev = (idir == 0) ? j : i;
                 // Convert to current level indices
-                const int idx_min =
-                    idx_lev + idx_lev * (rr - 1) * (current_level - lev);
-                const int idx_max =
-                    idx_min +
-                    amrex::max<int>(0, rr * (current_level - lev) - 1);
+                const int idx_min = idx_lev * rr;
+                const int idx_max = idx_min + rr - 1;
 
                 for (int idx = idx_min; idx <= idx_max; ++idx) {
                     const auto liquid_height =

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -377,6 +377,9 @@ void Flather::set_velocity(
         }
 
         const int idir = ori.coordDir();
+        if (idir == 2) {
+            continue;
+        }
         // Check if orientation aligns with supplied field and choose component
         bool skip_fill = false;
         int fcomp = 0;

--- a/src/boundary_conditions/field_boundary_fill/Flather.cpp
+++ b/src/boundary_conditions/field_boundary_fill/Flather.cpp
@@ -293,6 +293,7 @@ void Flather::compute_internal_z_averages()
     m_xhi_h.copy_host_to_device();
     m_ylo_h.copy_host_to_device();
     m_yhi_h.copy_host_to_device();
+    amrex::Gpu::streamSynchronize();
 }
 
 void Flather::compute_boundary_z_averages(
@@ -344,6 +345,7 @@ void Flather::compute_boundary_z_averages(
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, m_yhi_bnd_h.host_data(lev).begin(),
         m_yhi_bnd_h.host_data(lev).end(), m_yhi_bnd_h.device_data(lev).begin());
+    amrex::Gpu::streamSynchronize();
 }
 
 void Flather::set_velocity(

--- a/src/boundary_conditions/field_boundary_fill/ModulatedPowerLaw.cpp
+++ b/src/boundary_conditions/field_boundary_fill/ModulatedPowerLaw.cpp
@@ -71,8 +71,8 @@ ModulatedPowerLaw::ModulatedPowerLaw(CFDSim& sim)
 
 void ModulatedPowerLaw::post_init_actions()
 {
-    m_velocity.register_fill_patch_op<FillMPL>(m_mesh, m_time, *this);
-    m_temperature.register_fill_patch_op<FillMPL>(m_mesh, m_time, *this);
+    m_velocity.add_fill_patch_op<FillMPL>(m_mesh, m_time, *this);
+    m_temperature.add_fill_patch_op<FillMPL>(m_mesh, m_time, *this);
 }
 
 void ModulatedPowerLaw::pre_advance_work()

--- a/src/boundary_conditions/field_boundary_fill/OceanWavesBoundary.cpp
+++ b/src/boundary_conditions/field_boundary_fill/OceanWavesBoundary.cpp
@@ -35,9 +35,8 @@ void OceanWavesBoundary::post_init_actions()
     if (m_vof_exists) {
         m_repo.get_field("vof").add_fill_patch_op<OceanWavesFillInflow>(
             m_mesh, m_time, *this);
-        m_repo.get_field("density")
-            .add_fill_patch_op<OceanWavesFillInflow>(
-                m_mesh, m_time, *this);
+        m_repo.get_field("density").add_fill_patch_op<OceanWavesFillInflow>(
+            m_mesh, m_time, *this);
     }
 
     m_terrain_exists = m_repo.int_field_exists("terrain_blank");

--- a/src/boundary_conditions/field_boundary_fill/OceanWavesBoundary.cpp
+++ b/src/boundary_conditions/field_boundary_fill/OceanWavesBoundary.cpp
@@ -30,13 +30,13 @@ void OceanWavesBoundary::post_init_actions()
 {
     BL_PROFILE("kynema-sgf::OceanWavesBoundary::post_init_actions");
     m_repo.get_field("velocity")
-        .register_fill_patch_op<OceanWavesFillInflow>(m_mesh, m_time, *this);
+        .add_fill_patch_op<OceanWavesFillInflow>(m_mesh, m_time, *this);
     m_vof_exists = m_repo.field_exists("vof");
     if (m_vof_exists) {
-        m_repo.get_field("vof").register_fill_patch_op<OceanWavesFillInflow>(
+        m_repo.get_field("vof").add_fill_patch_op<OceanWavesFillInflow>(
             m_mesh, m_time, *this);
         m_repo.get_field("density")
-            .register_fill_patch_op<OceanWavesFillInflow>(
+            .add_fill_patch_op<OceanWavesFillInflow>(
                 m_mesh, m_time, *this);
     }
 

--- a/src/boundary_conditions/field_boundary_fill/OceanWavesFillInflow.cpp
+++ b/src/boundary_conditions/field_boundary_fill/OceanWavesFillInflow.cpp
@@ -24,9 +24,6 @@ void OceanWavesFillInflow::fillpatch(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "vof") {
@@ -43,9 +40,6 @@ void OceanWavesFillInflow::fillpatch_from_coarse(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_from_coarse(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "vof") {
@@ -62,9 +56,6 @@ void OceanWavesFillInflow::fillphysbc(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
-        lev, time, mfab, nghost, fstate);
-
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);
     } else if (m_field.base_name() == "vof") {

--- a/src/boundary_conditions/field_boundary_fill/OceanWavesFillInflow.cpp
+++ b/src/boundary_conditions/field_boundary_fill/OceanWavesFillInflow.cpp
@@ -21,8 +21,8 @@ void OceanWavesFillInflow::fillpatch(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);
@@ -37,8 +37,8 @@ void OceanWavesFillInflow::fillpatch_from_coarse(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);
@@ -53,8 +53,8 @@ void OceanWavesFillInflow::fillphysbc(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     if (m_field.base_name() == "velocity") {
         m_ow_bndry.set_velocity(lev, time, m_field, mfab);

--- a/src/boundary_conditions/field_boundary_fill/PlaneFillInflow.cpp
+++ b/src/boundary_conditions/field_boundary_fill/PlaneFillInflow.cpp
@@ -20,8 +20,8 @@ void PlaneFillInflow::fillpatch(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
@@ -30,8 +30,8 @@ void PlaneFillInflow::fillpatch_from_coarse(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
@@ -40,8 +40,8 @@ void PlaneFillInflow::fillphysbc(
     int lev,
     amrex::Real time,
     amrex::MultiFab& mfab,
-    const amrex::IntVect& nghost,
-    const FieldState fstate)
+    const amrex::IntVect& /* nghost */,
+    const FieldState /* fstate */)
 {
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }

--- a/src/boundary_conditions/field_boundary_fill/PlaneFillInflow.cpp
+++ b/src/boundary_conditions/field_boundary_fill/PlaneFillInflow.cpp
@@ -23,9 +23,6 @@ void PlaneFillInflow::fillpatch(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch(
-        lev, time, mfab, nghost, fstate);
-
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
 
@@ -36,9 +33,6 @@ void PlaneFillInflow::fillpatch_from_coarse(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillpatch_from_coarse(
-        lev, time, mfab, nghost, fstate);
-
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
 
@@ -49,9 +43,6 @@ void PlaneFillInflow::fillphysbc(
     const amrex::IntVect& nghost,
     const FieldState fstate)
 {
-    FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
-        lev, time, mfab, nghost, fstate);
-
     m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
 

--- a/src/core/Field.H
+++ b/src/core/Field.H
@@ -71,7 +71,7 @@ struct FieldInfo
     amrex::Vector<Field*> m_states;
 
     //! Function that handles filling patch and physics BC data for this field
-    std::unique_ptr<FieldFillPatchOpsBase> m_fillpatch_op;
+    amrex::Vector<std::unique_ptr<FieldFillPatchOpsBase>> m_fillpatch_ops;
 
     //! Custom boundary condition actions for this field
     amrex::Vector<std::unique_ptr<FieldBCIface>> m_bc_func;
@@ -222,7 +222,7 @@ public:
     //! Return a flag indicating whether a fillpatch Op has been registered
     [[nodiscard]] bool has_fillpatch_op() const
     {
-        return static_cast<bool>(m_info->m_fillpatch_op);
+        return static_cast<bool>(!m_info->m_fillpatch_ops.empty());
     }
 
     /** Setup default BC conditions for fillpatch operations
@@ -312,7 +312,25 @@ public:
     template <typename T, class... Args>
     void register_fill_patch_op(Args&&... args)
     {
-        m_info->m_fillpatch_op.reset(new T(*this, std::forward<Args>(args)...));
+        if (m_info->m_fillpatch_ops.empty()) {
+            m_info->m_fillpatch_ops.emplace_back(
+                new T(*this, std::forward<Args>(args)...));
+        } else if (m_info->m_fillpatch_ops.size() == 1) {
+            m_info->m_fillpatch_ops[0].reset(
+                new T(*this, std::forward<Args>(args)...));
+        } else {
+            amrex::Abort(
+                "register_fill_patch_op: More than one fillpatch op already "
+                "registered. register_fill_patch_op cannot be called after "
+                "add_fill_patch_op");
+        }
+    }
+
+    template <typename T, class... Args>
+    void add_fill_patch_op(Args&&... args)
+    {
+        m_info->m_fillpatch_ops.emplace_back(
+            new T(*this, std::forward<Args>(args)...));
     }
 
     /** Register a custom boundary conditions class

--- a/src/core/Field.H
+++ b/src/core/Field.H
@@ -222,7 +222,7 @@ public:
     //! Return a flag indicating whether a fillpatch Op has been registered
     [[nodiscard]] bool has_fillpatch_op() const
     {
-        return static_cast<bool>(!m_info->m_fillpatch_ops.empty());
+        return !m_info->m_fillpatch_ops.empty();
     }
 
     /** Setup default BC conditions for fillpatch operations

--- a/src/core/Field.cpp
+++ b/src/core/Field.cpp
@@ -173,7 +173,7 @@ void Field::fillpatch(
     const amrex::IntVect& nghost)
 {
     BL_PROFILE("kynema-sgf::Field::fillpatch 2");
-    BL_ASSERT(!m_info->m_fillpatch_ops.empty()); 
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
 
     for (const auto& fop : m_info->m_fillpatch_ops) {

--- a/src/core/Field.cpp
+++ b/src/core/Field.cpp
@@ -404,7 +404,7 @@ void Field::set_default_fillpatch_bc(
         bc_op();
     }
 
-    if (!m_info->m_fillpatch_ops[0]) {
+    if (m_info->m_fillpatch_ops.empty()) {
         register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
             repo().mesh(), time);
     }

--- a/src/core/Field.cpp
+++ b/src/core/Field.cpp
@@ -173,11 +173,12 @@ void Field::fillpatch(
     const amrex::IntVect& nghost)
 {
     BL_PROFILE("kynema-sgf::Field::fillpatch 2");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty()); 
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
 
-    fop.fillpatch(lev, time, mfab, nghost, field_state());
+    for (const auto& fop : m_info->m_fillpatch_ops) {
+        fop->fillpatch(lev, time, mfab, nghost, field_state());
+    }
 }
 
 void Field::fillpatch_from_coarse(
@@ -187,23 +188,24 @@ void Field::fillpatch_from_coarse(
     const amrex::IntVect& nghost)
 {
     BL_PROFILE("kynema-sgf::Field::fillpatch_from_coarse");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
-
-    fop.fillpatch_from_coarse(lev, time, mfab, nghost, field_state());
+    for (const auto& fop : m_info->m_fillpatch_ops) {
+        fop->fillpatch_from_coarse(lev, time, mfab, nghost, field_state());
+    }
 }
 
 void Field::fillpatch(const amrex::Real time, const amrex::IntVect ng)
 {
     BL_PROFILE("kynema-sgf::Field::fillpatch");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
     const int nlevels = m_repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
-        fop.fillpatch(
-            lev, time, m_repo.get_multifab(m_id, lev), ng, field_state());
+        for (const auto& fop : m_info->m_fillpatch_ops) {
+            fop->fillpatch(
+                lev, time, m_repo.get_multifab(m_id, lev), ng, field_state());
+        }
     }
 }
 
@@ -215,10 +217,9 @@ void Field::fillpatch_sibling_fields(
     amrex::Array<Field*, AMREX_SPACEDIM>& fields) const
 {
     BL_PROFILE("kynema-sgf::Field::fillpatch array");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
     BL_ASSERT(m_info->m_ncomp == static_cast<int>(fields.size()));
-    auto& fop = *(m_info->m_fillpatch_op);
     const int nlevels = m_repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
         amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM> mfabs = {AMREX_D_DECL(
@@ -230,9 +231,11 @@ void Field::fillpatch_sibling_fields(
             }
         }
 
-        fop.fillpatch_sibling_fields(
-            lev, time, mfabs, mfabs, cfabs, ng, m_info->m_bcrec,
-            m_info->m_bcrec, field_state());
+        for (const auto& fop : m_info->m_fillpatch_ops) {
+            fop->fillpatch_sibling_fields(
+                lev, time, mfabs, mfabs, cfabs, ng, m_info->m_bcrec,
+                m_info->m_bcrec, field_state());
+        }
     }
 }
 
@@ -243,22 +246,24 @@ void Field::fillphysbc(
     const amrex::IntVect& ng)
 {
     BL_PROFILE("kynema-sgf::Field::fillphysbc");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
-    fop.fillphysbc(lev, time, mfab, ng, field_state());
+    for (const auto& fop : m_info->m_fillpatch_ops) {
+        fop->fillphysbc(lev, time, mfab, ng, field_state());
+    }
 }
 
 void Field::fillphysbc(const amrex::Real time, const amrex::IntVect ng)
 {
     BL_PROFILE("kynema-sgf::Field::fillphysbc");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
     const int nlevels = m_repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
-        fop.fillphysbc(
-            lev, time, m_repo.get_multifab(m_id, lev), ng, field_state());
+        for (const auto& fop : m_info->m_fillpatch_ops) {
+            fop->fillphysbc(
+                lev, time, m_repo.get_multifab(m_id, lev), ng, field_state());
+        }
     }
 }
 
@@ -268,17 +273,18 @@ void Field::fillphysbc_type(
     const amrex::Real time, const amrex::BCType::mathematicalBndryTypes bctype)
 {
     BL_PROFILE("kynema-sgf::Field::fillphysbc_type");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     // BC does not need to be initialized to fill BCs with a specified type, but
     // it does need to be copied to device (e.g., if requested type needs data)
     BL_ASSERT(m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
     const int nlevels = m_repo.num_active_levels();
     const auto ng = num_grow();
     for (int lev = 0; lev < nlevels; ++lev) {
-        fop.fillphysbc_type(
-            lev, time, bctype, m_repo.get_multifab(m_id, lev), ng,
-            field_state());
+        for (const auto& fop : m_info->m_fillpatch_ops) {
+            fop->fillphysbc_type(
+                lev, time, bctype, m_repo.get_multifab(m_id, lev), ng,
+                field_state());
+        }
     }
 }
 
@@ -297,10 +303,11 @@ void Field::set_inflow(
     const amrex::IntVect& ng)
 {
     BL_PROFILE("kynema-sgf::Field::set_inflow");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
-    fop.set_inflow(lev, time, mfab, ng, field_state());
+    for (const auto& fop : m_info->m_fillpatch_ops) {
+        fop->set_inflow(lev, time, mfab, ng, field_state());
+    }
 }
 
 void Field::set_inflow_sibling_fields(
@@ -309,10 +316,11 @@ void Field::set_inflow_sibling_fields(
     const amrex::Array<amrex::MultiFab*, AMREX_SPACEDIM> mfabs)
 {
     BL_PROFILE("kynema-sgf::Field::set_inflow_sibling_fields");
-    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(!m_info->m_fillpatch_ops.empty());
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
-    auto& fop = *(m_info->m_fillpatch_op);
-    fop.set_inflow_sibling_fields(lev, time, mfabs);
+    for (const auto& fop : m_info->m_fillpatch_ops) {
+        fop->set_inflow_sibling_fields(lev, time, mfabs);
+    }
 }
 
 void Field::advance_states()
@@ -396,7 +404,7 @@ void Field::set_default_fillpatch_bc(
         bc_op();
     }
 
-    if (!m_info->m_fillpatch_op) {
+    if (!m_info->m_fillpatch_ops[0]) {
         register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
             repo().mesh(), time);
     }

--- a/src/projection/incflo_apply_nodal_projection.cpp
+++ b/src/projection/incflo_apply_nodal_projection.cpp
@@ -306,7 +306,7 @@ void incflo::ApplyProjection(
     amrex::Vector<amrex::MultiFab*> vel;
     for (int lev = 0; lev <= finest_level; ++lev) {
         vel.push_back(&(velocity(lev)));
-        vel[lev]->setBndry(0.0_rt);
+        vel[lev]->setDomainBndry(0.0_rt, geom[lev]);
         if (!proj_for_small_dt and !incremental) {
             kynema_sgf::nodal_projection::set_inflow_velocity(
                 m_sim.field_boundaries(), velocity, lev, time, *vel[lev], 1);

--- a/src/utilities/MultiLevelVector.H
+++ b/src/utilities/MultiLevelVector.H
@@ -43,6 +43,11 @@ public:
         return m_data_d[lev];
     };
 
+    amrex::Gpu::DeviceVector<amrex::Real>& device_data(const int lev)
+    {
+        return m_data_d[lev];
+    };
+
     void copy_host_to_device();
 
     void copy_to_field(Field& fld);

--- a/src/utilities/diagnostics.cpp
+++ b/src/utilities/diagnostics.cpp
@@ -108,16 +108,23 @@ amrex::Real kynema_sgf::diagnostics::get_vel_max(
     const int vdir,
     const amrex::Real factor)
 {
+    const int ng = 1;
     return amrex::ReduceMax(
-        vel, level_mask, 0,
+        vel, level_mask, ng,
         [=] AMREX_GPU_HOST_DEVICE(
             amrex::Box const& bx,
             amrex::Array4<amrex::Real const> const& vel_arr,
             amrex::Array4<int const> const& mask_arr) -> amrex::Real {
             amrex::Real max_fab = -1.0e8_rt;
             amrex::Loop(bx, [=, &max_fab](int i, int j, int k) {
+                const int ii = amrex::max<int>(
+                    bx.smallEnd(0) + ng, amrex::min<int>(i, bx.bigEnd(0) - ng));
+                const int jj = amrex::max<int>(
+                    bx.smallEnd(1) + ng, amrex::min<int>(j, bx.bigEnd(1) - ng));
+                const int kk = amrex::max<int>(
+                    bx.smallEnd(2) + ng, amrex::min<int>(k, bx.bigEnd(2) - ng));
                 max_fab = amrex::max<amrex::Real>(
-                    max_fab, mask_arr(i, j, k) > 0
+                    max_fab, mask_arr(ii, jj, kk) > 0
                                  ? factor * vel_arr(i, j, k, vdir)
                                  : std::numeric_limits<amrex::Real>::lowest());
             });
@@ -150,8 +157,9 @@ amrex::Real kynema_sgf::diagnostics::get_vel_loc(
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> problo,
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
+    const int ng = 1;
     return amrex::ReduceMax(
-        vel, level_mask, 0,
+        vel, level_mask, ng,
         [=] AMREX_GPU_HOST_DEVICE(
             amrex::Box const& bx,
             amrex::Array4<amrex::Real const> const& vel_arr,
@@ -159,9 +167,15 @@ amrex::Real kynema_sgf::diagnostics::get_vel_loc(
             amrex::Real loc_fab = problo[ldir];
             amrex::Loop(bx, [=, &loc_fab](int i, int j, int k) {
                 int idx = (ldir == 0 ? i : (ldir == 1 ? j : k));
+                const int ii = amrex::max<int>(
+                    bx.smallEnd(0) + ng, amrex::min<int>(i, bx.bigEnd(0) - ng));
+                const int jj = amrex::max<int>(
+                    bx.smallEnd(1) + ng, amrex::min<int>(j, bx.bigEnd(1) - ng));
+                const int kk = amrex::max<int>(
+                    bx.smallEnd(2) + ng, amrex::min<int>(k, bx.bigEnd(2) - ng));
                 amrex::Real offset = 0.5_rt;
                 amrex::Real loc = problo[ldir] + ((idx + offset) * dx[ldir]);
-                bool mask_check = (mask_arr(i, j, k) > 0);
+                bool mask_check = (mask_arr(ii, jj, kk) > 0);
                 bool loc_check =
                     (amrex::Math::abs(vel_max - vel_arr(i, j, k, vdir)) <
                      std::numeric_limits<amrex::Real>::epsilon() * 1.0e6_rt);

--- a/src/utilities/diagnostics.cpp
+++ b/src/utilities/diagnostics.cpp
@@ -108,23 +108,16 @@ amrex::Real kynema_sgf::diagnostics::get_vel_max(
     const int vdir,
     const amrex::Real factor)
 {
-    const int ng = 1;
     return amrex::ReduceMax(
-        vel, level_mask, ng,
+        vel, level_mask, 0,
         [=] AMREX_GPU_HOST_DEVICE(
             amrex::Box const& bx,
             amrex::Array4<amrex::Real const> const& vel_arr,
             amrex::Array4<int const> const& mask_arr) -> amrex::Real {
             amrex::Real max_fab = -1.0e8_rt;
             amrex::Loop(bx, [=, &max_fab](int i, int j, int k) {
-                const int ii = amrex::max<int>(
-                    bx.smallEnd(0) + ng, amrex::min<int>(i, bx.bigEnd(0) - ng));
-                const int jj = amrex::max<int>(
-                    bx.smallEnd(1) + ng, amrex::min<int>(j, bx.bigEnd(1) - ng));
-                const int kk = amrex::max<int>(
-                    bx.smallEnd(2) + ng, amrex::min<int>(k, bx.bigEnd(2) - ng));
                 max_fab = amrex::max<amrex::Real>(
-                    max_fab, mask_arr(ii, jj, kk) > 0
+                    max_fab, mask_arr(i, j, k) > 0
                                  ? factor * vel_arr(i, j, k, vdir)
                                  : std::numeric_limits<amrex::Real>::lowest());
             });
@@ -157,9 +150,8 @@ amrex::Real kynema_sgf::diagnostics::get_vel_loc(
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> problo,
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
-    const int ng = 1;
     return amrex::ReduceMax(
-        vel, level_mask, ng,
+        vel, level_mask, 0,
         [=] AMREX_GPU_HOST_DEVICE(
             amrex::Box const& bx,
             amrex::Array4<amrex::Real const> const& vel_arr,
@@ -167,15 +159,9 @@ amrex::Real kynema_sgf::diagnostics::get_vel_loc(
             amrex::Real loc_fab = problo[ldir];
             amrex::Loop(bx, [=, &loc_fab](int i, int j, int k) {
                 int idx = (ldir == 0 ? i : (ldir == 1 ? j : k));
-                const int ii = amrex::max<int>(
-                    bx.smallEnd(0) + ng, amrex::min<int>(i, bx.bigEnd(0) - ng));
-                const int jj = amrex::max<int>(
-                    bx.smallEnd(1) + ng, amrex::min<int>(j, bx.bigEnd(1) - ng));
-                const int kk = amrex::max<int>(
-                    bx.smallEnd(2) + ng, amrex::min<int>(k, bx.bigEnd(2) - ng));
                 amrex::Real offset = 0.5_rt;
                 amrex::Real loc = problo[ldir] + ((idx + offset) * dx[ldir]);
-                bool mask_check = (mask_arr(ii, jj, kk) > 0);
+                bool mask_check = (mask_arr(i, j, k) > 0);
                 bool loc_check =
                     (amrex::Math::abs(vel_max - vel_arr(i, j, k, vdir)) <
                      std::numeric_limits<amrex::Real>::epsilon() * 1.0e6_rt);

--- a/test/test_files/channel_builder_multiphase_contraction/channel_builder_multiphase_contraction.inp
+++ b/test/test_files/channel_builder_multiphase_contraction/channel_builder_multiphase_contraction.inp
@@ -23,7 +23,7 @@ incflo.gravity        =  0.0  0.0 -9.81  # Gravitational force (3D)
 transport.model = TwoPhaseTransport
 turbulence.model = Laminar
 
-incflo.field_boundaries = BoundaryPlane
+incflo.field_boundaries = BoundaryPlane Flather
 BoundaryPlane.planes =  xlo
 BoundaryPlane.file = bndry_plane
 BoundaryPlane.var_names = velocity vof density

--- a/unit_tests/boundary_conditions/CMakeLists.txt
+++ b/unit_tests/boundary_conditions/CMakeLists.txt
@@ -2,5 +2,5 @@ target_sources(${kynema_sgf_unit_test_exe_name} PRIVATE
   # test cases
   test_log_law.cpp
   test_mosd.cpp
-  #test_flather.cpp
+  test_flather.cpp
   )

--- a/unit_tests/boundary_conditions/CMakeLists.txt
+++ b/unit_tests/boundary_conditions/CMakeLists.txt
@@ -2,5 +2,5 @@ target_sources(${kynema_sgf_unit_test_exe_name} PRIVATE
   # test cases
   test_log_law.cpp
   test_mosd.cpp
-  test_flather.cpp
+  #test_flather.cpp
   )

--- a/unit_tests/boundary_conditions/CMakeLists.txt
+++ b/unit_tests/boundary_conditions/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(${kynema_sgf_unit_test_exe_name} PRIVATE
   # test cases
   test_log_law.cpp
   test_mosd.cpp
+  test_flather.cpp
   )

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -249,10 +249,10 @@ TEST_F(
             lev, 1, -1, false, yhi_uh, yhi_h, true,
             kynema_sgf::FieldState::New);
 
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0, tol);
-        EXPECT_NEAR(xhi_uh.host_data(lev)[0], u0, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0, tol);
-        EXPECT_NEAR(yhi_uh.host_data(lev)[0], v0, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0 * m_wlev, tol);
+        EXPECT_NEAR(xhi_uh.host_data(lev)[0], u0 * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0 * m_wlev, tol);
+        EXPECT_NEAR(yhi_uh.host_data(lev)[0], v0 * m_wlev, tol);
 
         EXPECT_NEAR(xlo_h.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(xhi_h.host_data(lev)[0], m_wlev, tol);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -23,12 +23,12 @@ void initialize_vof(
             [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
                 const amrex::Real z = zlo + (k + 0.5_rt) * dz;
 
-                if (z + 0.5 * dz <= wlev) {
+                if (z + 0.5_rt * dz <= wlev) {
                     vof_arrs[nbx](i, j, k) = 1.0_rt;
-                } else if (z - 0.5 * dz >= wlev) {
+                } else if (z - 0.5_rt * dz >= wlev) {
                     vof_arrs[nbx](i, j, k) = 0.0_rt;
                 } else {
-                    vof_arrs[nbx](i, j, k) = (wlev - (z - 0.5 * dz)) / dz;
+                    vof_arrs[nbx](i, j, k) = (wlev - (z - 0.5_rt * dz)) / dz;
                 }
             });
     }

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -123,10 +123,18 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
     EXPECT_EQ(nlevels, 2);
 
     for (int lev = 0; lev < nlevels; ++lev) {
-        flather.accumulate_boundary(lev, 0, true, xlo_uavg, xlo_havg, false);
-        flather.accumulate_boundary(lev, 0, false, xhi_uavg, xhi_havg, false);
-        flather.accumulate_boundary(lev, 1, true, ylo_uavg, ylo_havg, false);
-        flather.accumulate_boundary(lev, 1, false, yhi_uavg, yhi_havg, false);
+        flather.accumulate_boundary(
+            lev, 0, true, xlo_uavg, xlo_havg, false,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 0, false, xhi_uavg, xhi_havg, false,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, true, ylo_uavg, ylo_havg, false,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, false, yhi_uavg, yhi_havg, false,
+            kynema_sgf::FieldState::New);
 
         const auto xhi_idx = xhi_uavg.ncells(lev) - 1;
         const auto yhi_idx = yhi_uavg.ncells(lev) - 1;
@@ -187,10 +195,18 @@ TEST_F(
     EXPECT_EQ(nlevels, 2);
 
     for (int lev = 0; lev < nlevels; ++lev) {
-        flather.accumulate_boundary(lev, 0, true, xlo_uavg, xlo_havg, true);
-        flather.accumulate_boundary(lev, 0, false, xhi_uavg, xhi_havg, true);
-        flather.accumulate_boundary(lev, 1, true, ylo_uavg, ylo_havg, true);
-        flather.accumulate_boundary(lev, 1, false, yhi_uavg, yhi_havg, true);
+        flather.accumulate_boundary(
+            lev, 0, true, xlo_uavg, xlo_havg, true,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 0, false, xhi_uavg, xhi_havg, true,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, true, ylo_uavg, ylo_havg, true,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, false, yhi_uavg, yhi_havg, true,
+            kynema_sgf::FieldState::New);
 
         EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
         EXPECT_NEAR(xhi_uavg.host_data(lev)[0], u0, tol);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -92,6 +92,7 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 
     auto& repo = mesh().field_repo();
     auto& velocity = repo.declare_field("velocity", 3, 1);
+    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
     auto& vof = repo.declare_field("vof", 1, 1);
 
     velocity.setVal(u0, 0, 1, 1);
@@ -164,6 +165,7 @@ TEST_F(
 
     auto& repo = mesh().field_repo();
     auto& velocity = repo.declare_field("velocity", 3, 1);
+    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
     auto& vof = repo.declare_field("vof", 1, 1);
 
     velocity.setVal(u0, 0, 1, 1);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -84,8 +84,6 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 {
     constexpr amrex::Real u0 = 2.0_rt;
     constexpr amrex::Real v0 = 3.0_rt;
-    constexpr amrex::Real u0_mac = 11.0_rt;
-    constexpr amrex::Real v0_mac = 13.0_rt;
     constexpr amrex::Real tol =
         std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
 
@@ -94,16 +92,12 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 
     auto& repo = mesh().field_repo();
     auto& velocity = repo.declare_field("velocity", 3, 1);
-    const auto mac_fields =
-        repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
+    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
     auto& vof = repo.declare_field("vof", 1, 1);
 
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
-    mac_fields[0]->setVal(u0_mac, 0, 1, 1);
-    mac_fields[1]->setVal(v0_mac, 0, 1, 1);
-    mac_fields[2]->setVal(0.0_rt, 0, 1, 1);
     initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
@@ -129,6 +123,8 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);
 
+    // Flow is in positive x and y (outflow at xhi and yhi)
+    // - means it is capped at other boundaries
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
             lev, 0, -1, true, xlo_uh, xlo_h, false,
@@ -146,43 +142,55 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         const auto xhi_idx = xhi_uh.ncells(lev) - 1;
         const auto yhi_idx = yhi_uh.ncells(lev) - 1;
 
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0 * m_wlev, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], 0.0_rt, tol);
         EXPECT_NEAR(xhi_uh.host_data(lev)[xhi_idx], u0 * m_wlev, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0 * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], 0.0_rt, tol);
         EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], v0 * m_wlev, tol);
 
         EXPECT_NEAR(xlo_h.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(xhi_h.host_data(lev)[xhi_idx], m_wlev, tol);
         EXPECT_NEAR(ylo_h.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(yhi_h.host_data(lev)[yhi_idx], m_wlev, tol);
+    }
 
-        // MAC velocity
+    velocity.setVal(-u0, 0, 1, 1);
+    velocity.setVal(-v0, 1, 1, 1);
+    // Flow is now reversed, opposite sides have outflow
+    for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, -1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
-            true);
+            lev, 0, -1, true, xlo_uh, xlo_h, false,
+            kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, -1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
-            true);
+            lev, 0, -1, false, xhi_uh, xhi_h, false,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, -1, true, ylo_uh, ylo_h, false,
+            kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 1, -1, false, yhi_uh, yhi_h, false,
+            kynema_sgf::FieldState::New);
 
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * m_wlev, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * m_wlev, tol);
+        const auto xhi_idx = xhi_uh.ncells(lev) - 1;
+        const auto yhi_idx = yhi_uh.ncells(lev) - 1;
+
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], 0.0_rt, tol);
+        EXPECT_NEAR(xhi_uh.host_data(lev)[xhi_idx], u0 * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], 0.0_rt, tol);
+        EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], v0 * m_wlev, tol);
 
         const auto dz = (8.0_rt / (m_nx * (lev + 1)));
+
         // Liquid only
         flather.accumulate_boundary(
-            lev, 0, 0, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
-            true);
-
+            lev, 0, 0, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New);
         const auto hliq = std::floor(m_wlev / dz) * dz;
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hliq, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], -u0 * hliq, tol);
 
         // Mix only
         flather.accumulate_boundary(
-            lev, 0, 1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
-            true);
-
+            lev, 0, 1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New);
         const auto hmix = m_wlev - hliq;
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hmix, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], -u0 * hmix, tol);
     }
 }
 
@@ -191,6 +199,8 @@ TEST_F(
 {
     constexpr amrex::Real u0 = 4.0_rt;
     constexpr amrex::Real v0 = 1.5_rt;
+    constexpr amrex::Real u0_mac = 11.0_rt;
+    constexpr amrex::Real v0_mac = 13.0_rt;
     constexpr amrex::Real tol =
         std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
 
@@ -199,12 +209,17 @@ TEST_F(
 
     auto& repo = mesh().field_repo();
     auto& velocity = repo.declare_field("velocity", 3, 1);
-    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
+
+    const auto mac_fields =
+        repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
     auto& vof = repo.declare_field("vof", 1, 1);
 
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
+    mac_fields[0]->setVal(u0_mac, 0, 1, 1);
+    mac_fields[1]->setVal(v0_mac, 0, 1, 1);
+    mac_fields[2]->setVal(0.0_rt, 0, 1, 1);
     initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
@@ -251,6 +266,17 @@ TEST_F(
         EXPECT_NEAR(xhi_h.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(ylo_h.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(yhi_h.host_data(lev)[0], m_wlev, tol);
+
+        // MAC velocity
+        flather.accumulate_boundary(
+            lev, 0, -1, true, xlo_uh, xlo_h, true, kynema_sgf::FieldState::New,
+            true);
+        flather.accumulate_boundary(
+            lev, 1, -1, true, ylo_uh, ylo_h, true, kynema_sgf::FieldState::New,
+            true);
+
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * m_wlev, tol);
     }
 }
 

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -77,13 +77,15 @@ protected:
     }
 
     const int m_nx{32};
-    const amrex::Real m_wlev{4.0_rt};
+    const amrex::Real m_wlev{4.5_rt};
 };
 
 TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 {
     constexpr amrex::Real u0 = 2.0_rt;
     constexpr amrex::Real v0 = 3.0_rt;
+    constexpr amrex::Real u0_mac = 11.0_rt;
+    constexpr amrex::Real v0_mac = 13.0_rt;
     constexpr amrex::Real tol =
         std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
 
@@ -99,70 +101,93 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
-    mac_fields[0]->setVal(11.0_rt, 0, 1, 1);
-    mac_fields[1]->setVal(13.0_rt, 0, 1, 1);
+    mac_fields[0]->setVal(u0_mac, 0, 1, 1);
+    mac_fields[1]->setVal(v0_mac, 0, 1, 1);
     mac_fields[2]->setVal(0.0_rt, 0, 1, 1);
     initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
 
-    kynema_sgf::MultiLevelVector xlo_uavg;
-    kynema_sgf::MultiLevelVector xlo_havg;
-    kynema_sgf::MultiLevelVector xhi_uavg;
-    kynema_sgf::MultiLevelVector xhi_havg;
-    kynema_sgf::MultiLevelVector ylo_uavg;
-    kynema_sgf::MultiLevelVector ylo_havg;
-    kynema_sgf::MultiLevelVector yhi_uavg;
-    kynema_sgf::MultiLevelVector yhi_havg;
+    kynema_sgf::MultiLevelVector xlo_uh;
+    kynema_sgf::MultiLevelVector xlo_h;
+    kynema_sgf::MultiLevelVector xhi_uh;
+    kynema_sgf::MultiLevelVector xhi_h;
+    kynema_sgf::MultiLevelVector ylo_uh;
+    kynema_sgf::MultiLevelVector ylo_h;
+    kynema_sgf::MultiLevelVector yhi_uh;
+    kynema_sgf::MultiLevelVector yhi_h;
 
-    xlo_uavg.resize(1, mesh().Geom());
-    xlo_havg.resize(1, mesh().Geom());
-    xhi_uavg.resize(1, mesh().Geom());
-    xhi_havg.resize(1, mesh().Geom());
-    ylo_uavg.resize(0, mesh().Geom());
-    ylo_havg.resize(0, mesh().Geom());
-    yhi_uavg.resize(0, mesh().Geom());
-    yhi_havg.resize(0, mesh().Geom());
+    xlo_uh.resize(1, mesh().Geom());
+    xlo_h.resize(1, mesh().Geom());
+    xhi_uh.resize(1, mesh().Geom());
+    xhi_h.resize(1, mesh().Geom());
+    ylo_uh.resize(0, mesh().Geom());
+    ylo_h.resize(0, mesh().Geom());
+    yhi_uh.resize(0, mesh().Geom());
+    yhi_h.resize(0, mesh().Geom());
 
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, 0, true, xlo_uavg, xlo_havg, false,
+            lev, 0, -1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New);
+        flather.accumulate_boundary(
+            lev, 0, -1, false, xhi_uh, xhi_h, false,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 0, 0, false, xhi_uavg, xhi_havg, false,
-            kynema_sgf::FieldState::New);
+            lev, 1, -1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, 0, true, ylo_uavg, ylo_havg, false,
-            kynema_sgf::FieldState::New);
-        flather.accumulate_boundary(
-            lev, 1, 0, false, yhi_uavg, yhi_havg, false,
+            lev, 1, -1, false, yhi_uh, yhi_h, false,
             kynema_sgf::FieldState::New);
 
-        const auto xhi_idx = xhi_uavg.ncells(lev) - 1;
-        const auto yhi_idx = yhi_uavg.ncells(lev) - 1;
+        const auto xhi_idx = xhi_uh.ncells(lev) - 1;
+        const auto yhi_idx = yhi_uh.ncells(lev) - 1;
 
-        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
-        EXPECT_NEAR(xhi_uavg.host_data(lev)[xhi_idx], u0, tol);
-        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
-        EXPECT_NEAR(yhi_uavg.host_data(lev)[yhi_idx], v0, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0 * m_wlev, tol);
+        EXPECT_NEAR(xhi_uh.host_data(lev)[xhi_idx], u0 * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0 * m_wlev, tol);
+        EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], v0 * m_wlev, tol);
 
-        EXPECT_NEAR(xlo_havg.host_data(lev)[0], m_wlev, tol);
-        EXPECT_NEAR(xhi_havg.host_data(lev)[xhi_idx], m_wlev, tol);
-        EXPECT_NEAR(ylo_havg.host_data(lev)[0], m_wlev, tol);
-        EXPECT_NEAR(yhi_havg.host_data(lev)[yhi_idx], m_wlev, tol);
+        EXPECT_NEAR(xlo_h.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(xhi_h.host_data(lev)[xhi_idx], m_wlev, tol);
+        EXPECT_NEAR(ylo_h.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(yhi_h.host_data(lev)[yhi_idx], m_wlev, tol);
 
+        // MAC velocity
         flather.accumulate_boundary(
-            lev, 0, 0, true, xlo_uavg, xlo_havg, false,
-            kynema_sgf::FieldState::New, true);
+            lev, 0, -1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
+            true);
         flather.accumulate_boundary(
-            lev, 1, 0, true, ylo_uavg, ylo_havg, false,
-            kynema_sgf::FieldState::New, true);
+            lev, 1, -1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
+            true);
 
-        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], 11.0_rt, tol);
-        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], 13.0_rt, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * m_wlev, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * m_wlev, tol);
+
+        // Liquid only
+        flather.accumulate_boundary(
+            lev, 0, 0, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
+            true);
+        flather.accumulate_boundary(
+            lev, 1, 0, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
+            true);
+
+        const auto hliq = std::floor(m_wlev);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hliq, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * hliq, tol);
+
+        // Mix only
+        flather.accumulate_boundary(
+            lev, 0, 1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
+            true);
+        flather.accumulate_boundary(
+            lev, 1, 1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
+            true);
+
+        const auto hmix = m_wlev - std::floor(m_wlev);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hmix, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * hmix, tol);
     }
 }
 
@@ -189,50 +214,46 @@ TEST_F(
 
     kynema_sgf::Flather flather(sim());
 
-    kynema_sgf::MultiLevelVector xlo_uavg;
-    kynema_sgf::MultiLevelVector xlo_havg;
-    kynema_sgf::MultiLevelVector xhi_uavg;
-    kynema_sgf::MultiLevelVector xhi_havg;
-    kynema_sgf::MultiLevelVector ylo_uavg;
-    kynema_sgf::MultiLevelVector ylo_havg;
-    kynema_sgf::MultiLevelVector yhi_uavg;
-    kynema_sgf::MultiLevelVector yhi_havg;
+    kynema_sgf::MultiLevelVector xlo_uh;
+    kynema_sgf::MultiLevelVector xlo_h;
+    kynema_sgf::MultiLevelVector xhi_uh;
+    kynema_sgf::MultiLevelVector xhi_h;
+    kynema_sgf::MultiLevelVector ylo_uh;
+    kynema_sgf::MultiLevelVector ylo_h;
+    kynema_sgf::MultiLevelVector yhi_uh;
+    kynema_sgf::MultiLevelVector yhi_h;
 
-    xlo_uavg.resize(1, mesh().Geom());
-    xlo_havg.resize(1, mesh().Geom());
-    xhi_uavg.resize(1, mesh().Geom());
-    xhi_havg.resize(1, mesh().Geom());
-    ylo_uavg.resize(0, mesh().Geom());
-    ylo_havg.resize(0, mesh().Geom());
-    yhi_uavg.resize(0, mesh().Geom());
-    yhi_havg.resize(0, mesh().Geom());
+    xlo_uh.resize(1, mesh().Geom());
+    xlo_h.resize(1, mesh().Geom());
+    xhi_uh.resize(1, mesh().Geom());
+    xhi_h.resize(1, mesh().Geom());
+    ylo_uh.resize(0, mesh().Geom());
+    ylo_h.resize(0, mesh().Geom());
+    yhi_uh.resize(0, mesh().Geom());
+    yhi_h.resize(0, mesh().Geom());
 
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, 0, true, xlo_uavg, xlo_havg, true,
-            kynema_sgf::FieldState::New);
+            lev, 0, -1, true, xlo_uh, xlo_h, true, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 0, 0, false, xhi_uavg, xhi_havg, true,
-            kynema_sgf::FieldState::New);
+            lev, 0, -1, false, xhi_uh, xhi_h, true, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, 0, true, ylo_uavg, ylo_havg, true,
-            kynema_sgf::FieldState::New);
+            lev, 1, -1, true, ylo_uh, ylo_h, true, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, 0, false, yhi_uavg, yhi_havg, true,
-            kynema_sgf::FieldState::New);
+            lev, 1, -1, false, yhi_uh, yhi_h, true, kynema_sgf::FieldState::New);
 
-        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
-        EXPECT_NEAR(xhi_uavg.host_data(lev)[0], u0, tol);
-        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
-        EXPECT_NEAR(yhi_uavg.host_data(lev)[0], v0, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0, tol);
+        EXPECT_NEAR(xhi_uh.host_data(lev)[0], u0, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0, tol);
+        EXPECT_NEAR(yhi_uh.host_data(lev)[0], v0, tol);
 
-        EXPECT_NEAR(xlo_havg.host_data(lev)[0], m_wlev, tol);
-        EXPECT_NEAR(xhi_havg.host_data(lev)[0], m_wlev, tol);
-        EXPECT_NEAR(ylo_havg.host_data(lev)[0], m_wlev, tol);
-        EXPECT_NEAR(yhi_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(xlo_h.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(xhi_h.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(ylo_h.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(yhi_h.host_data(lev)[0], m_wlev, tol);
     }
 }
 

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -7,6 +7,34 @@ using namespace amrex::literals;
 
 namespace kynema_sgf_tests {
 
+namespace {
+void initialize_vof(
+    kynema_sgf::Field& vof,
+    const amrex::Vector<amrex::Geometry>& geom,
+    amrex::Real wlev)
+{
+    for (int lev = 0; lev < vof.repo().num_active_levels(); ++lev) {
+        auto& vof_mfab = vof(lev);
+        auto vof_arrs = vof_mfab.arrays();
+        const auto& zlo = geom[lev].ProbLo(2);
+        const auto& dz = geom[lev].CellSize(2);
+        amrex::ParallelFor(
+            vof_mfab, amrex::IntVect(1),
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                const amrex::Real z = zlo + (k + 0.5_rt) * dz;
+
+                if (z + 0.5 * dz <= wlev) {
+                    vof_arrs[nbx](i, j, k) = 1.0_rt;
+                } else if (z - 0.5 * dz >= wlev) {
+                    vof_arrs[nbx](i, j, k) = 0.0_rt;
+                } else {
+                    vof_arrs[nbx](i, j, k) = (wlev - (z - 0.5 * dz)) / dz;
+                }
+            });
+    }
+}
+} // namespace
+
 class FlatherBoundaryAverageTest : public MeshTest
 {
 protected:
@@ -35,7 +63,7 @@ protected:
         std::stringstream ss;
         ss << "1 // Number of levels" << '\n';
         ss << "1 // Number of boxes at this level" << '\n';
-        ss << "0 0 0 8 8 8" << '\n';
+        ss << "3 3 3 5 5 5" << '\n';
 
         create_mesh_instance<RefineMesh>();
         std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(
@@ -48,21 +76,8 @@ protected:
         }
     }
 
-    static amrex::Real expected_h_x(const amrex::Geometry& geom)
-    {
-        const auto& dom = geom.Domain();
-        return static_cast<amrex::Real>(dom.length(1) * dom.length(2)) *
-               geom.CellSize(2);
-    }
-
-    static amrex::Real expected_h_y(const amrex::Geometry& geom)
-    {
-        const auto& dom = geom.Domain();
-        return static_cast<amrex::Real>(dom.length(0) * dom.length(2)) *
-               geom.CellSize(2);
-    }
-
-    const int m_nx{8};
+    const int m_nx{32};
+    const amrex::Real m_wlev{4.0_rt};
 };
 
 TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
@@ -82,7 +97,7 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
-    vof.setVal(1.0_rt, 0, 1, 1);
+    initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
 
@@ -121,16 +136,15 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
         EXPECT_NEAR(yhi_uavg.host_data(lev)[yhi_idx], v0, tol);
 
-        const auto hx = expected_h_x(mesh().Geom(lev));
-        const auto hy = expected_h_y(mesh().Geom(lev));
-        EXPECT_NEAR(xlo_havg.host_data(lev)[0], hx, tol);
-        EXPECT_NEAR(xhi_havg.host_data(lev)[xhi_idx], hx, tol);
-        EXPECT_NEAR(ylo_havg.host_data(lev)[0], hy, tol);
-        EXPECT_NEAR(yhi_havg.host_data(lev)[yhi_idx], hy, tol);
+        EXPECT_NEAR(xlo_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(xhi_havg.host_data(lev)[xhi_idx], m_wlev, tol);
+        EXPECT_NEAR(ylo_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(yhi_havg.host_data(lev)[yhi_idx], m_wlev, tol);
     }
 }
 
-TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel_boundary_cells)
+TEST_F(
+    FlatherBoundaryAverageTest, accumulate_boundary_multilevel_boundary_cells)
 {
     constexpr amrex::Real u0 = 4.0_rt;
     constexpr amrex::Real v0 = 1.5_rt;
@@ -147,32 +161,46 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel_boundary_cells
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
-    vof.setVal(1.0_rt, 0, 1, 1);
+    initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
 
     kynema_sgf::MultiLevelVector xlo_uavg;
     kynema_sgf::MultiLevelVector xlo_havg;
+    kynema_sgf::MultiLevelVector xhi_uavg;
+    kynema_sgf::MultiLevelVector xhi_havg;
     kynema_sgf::MultiLevelVector ylo_uavg;
     kynema_sgf::MultiLevelVector ylo_havg;
+    kynema_sgf::MultiLevelVector yhi_uavg;
+    kynema_sgf::MultiLevelVector yhi_havg;
 
     xlo_uavg.resize(0, mesh().Geom());
     xlo_havg.resize(0, mesh().Geom());
+    xhi_uavg.resize(0, mesh().Geom());
+    xhi_havg.resize(0, mesh().Geom());
     ylo_uavg.resize(1, mesh().Geom());
     ylo_havg.resize(1, mesh().Geom());
+    yhi_uavg.resize(1, mesh().Geom());
+    yhi_havg.resize(1, mesh().Geom());
 
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(lev, 0, true, xlo_uavg, xlo_havg, true);
+        flather.accumulate_boundary(lev, 0, false, xhi_uavg, xhi_havg, true);
         flather.accumulate_boundary(lev, 1, true, ylo_uavg, ylo_havg, true);
+        flather.accumulate_boundary(lev, 1, false, yhi_uavg, yhi_havg, true);
 
         EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
+        EXPECT_NEAR(xhi_uavg.host_data(lev)[0], u0, tol);
         EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
+        EXPECT_NEAR(yhi_uavg.host_data(lev)[0], v0, tol);
 
-        EXPECT_NEAR(xlo_havg.host_data(lev)[0], expected_h_x(mesh().Geom(lev)), tol);
-        EXPECT_NEAR(ylo_havg.host_data(lev)[0], expected_h_y(mesh().Geom(lev)), tol);
+        EXPECT_NEAR(xlo_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(xhi_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(ylo_havg.host_data(lev)[0], m_wlev, tol);
+        EXPECT_NEAR(yhi_havg.host_data(lev)[0], m_wlev, tol);
     }
 }
 

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -1,0 +1,179 @@
+#include "gtest/gtest.h"
+#include "ks_test_utils/MeshTest.H"
+#include "src/boundary_conditions/field_boundary_fill/Flather.H"
+#include "AMReX_REAL.H"
+
+using namespace amrex::literals;
+
+namespace kynema_sgf_tests {
+
+class FlatherBoundaryAverageTest : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0_rt, 0.0_rt, 0.0_rt}};
+            amrex::Vector<amrex::Real> probhi{{8.0_rt, 8.0_rt, 8.0_rt}};
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+            amrex::Vector<int> periodic{{0, 0, 0}};
+            pp.addarr("is_periodic", periodic);
+        }
+        {
+            amrex::ParmParse pp("amr");
+            const amrex::Vector<int> ncell{{m_nx, m_nx, m_nx}};
+            pp.add("max_level", 1);
+            pp.add("max_grid_size", m_nx);
+            pp.add("blocking_factor", 2);
+            pp.addarr("n_cell", ncell);
+        }
+
+        std::stringstream ss;
+        ss << "1 // Number of levels" << '\n';
+        ss << "1 // Number of boxes at this level" << '\n';
+        ss << "0 0 0 8 8 8" << '\n';
+
+        create_mesh_instance<RefineMesh>();
+        std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(
+            new kynema_sgf::CartBoxRefinement(sim()));
+        box_refine->read_inputs(mesh(), ss);
+
+        if (mesh<RefineMesh>() != nullptr) {
+            mesh<RefineMesh>()->refine_criteria_vec().push_back(
+                std::move(box_refine));
+        }
+    }
+
+    static amrex::Real expected_h_x(const amrex::Geometry& geom)
+    {
+        const auto& dom = geom.Domain();
+        return static_cast<amrex::Real>(dom.length(1) * dom.length(2)) *
+               geom.CellSize(2);
+    }
+
+    static amrex::Real expected_h_y(const amrex::Geometry& geom)
+    {
+        const auto& dom = geom.Domain();
+        return static_cast<amrex::Real>(dom.length(0) * dom.length(2)) *
+               geom.CellSize(2);
+    }
+
+    const int m_nx{8};
+};
+
+TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
+{
+    constexpr amrex::Real u0 = 2.0_rt;
+    constexpr amrex::Real v0 = 3.0_rt;
+    constexpr amrex::Real tol =
+        std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
+
+    populate_parameters();
+    initialize_mesh();
+
+    auto& repo = mesh().field_repo();
+    auto& velocity = repo.declare_field("velocity", 3, 1);
+    auto& vof = repo.declare_field("vof", 1, 1);
+
+    velocity.setVal(u0, 0, 1, 1);
+    velocity.setVal(v0, 1, 1, 1);
+    velocity.setVal(0.0_rt, 2, 1, 1);
+    vof.setVal(1.0_rt, 0, 1, 1);
+
+    kynema_sgf::Flather flather(sim());
+
+    kynema_sgf::MultiLevelVector xlo_uavg;
+    kynema_sgf::MultiLevelVector xlo_havg;
+    kynema_sgf::MultiLevelVector xhi_uavg;
+    kynema_sgf::MultiLevelVector xhi_havg;
+    kynema_sgf::MultiLevelVector ylo_uavg;
+    kynema_sgf::MultiLevelVector ylo_havg;
+    kynema_sgf::MultiLevelVector yhi_uavg;
+    kynema_sgf::MultiLevelVector yhi_havg;
+
+    xlo_uavg.resize(0, mesh().Geom());
+    xlo_havg.resize(0, mesh().Geom());
+    xhi_uavg.resize(0, mesh().Geom());
+    xhi_havg.resize(0, mesh().Geom());
+    ylo_uavg.resize(1, mesh().Geom());
+    ylo_havg.resize(1, mesh().Geom());
+    yhi_uavg.resize(1, mesh().Geom());
+    yhi_havg.resize(1, mesh().Geom());
+
+    const int nlevels = repo.num_active_levels();
+    EXPECT_EQ(nlevels, 2);
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        flather.accumulate_boundary(lev, 0, true, xlo_uavg, xlo_havg, false);
+        flather.accumulate_boundary(lev, 0, false, xhi_uavg, xhi_havg, false);
+        flather.accumulate_boundary(lev, 1, true, ylo_uavg, ylo_havg, false);
+        flather.accumulate_boundary(lev, 1, false, yhi_uavg, yhi_havg, false);
+
+        const auto xhi_idx = xhi_uavg.ncells(lev) - 1;
+        const auto yhi_idx = yhi_uavg.ncells(lev) - 1;
+
+        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
+        EXPECT_NEAR(xhi_uavg.host_data(lev)[xhi_idx], u0, tol);
+        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
+        EXPECT_NEAR(yhi_uavg.host_data(lev)[yhi_idx], v0, tol);
+
+        const auto hx = expected_h_x(mesh().Geom(lev));
+        const auto hy = expected_h_y(mesh().Geom(lev));
+        EXPECT_NEAR(xlo_havg.host_data(lev)[0], hx, tol);
+        EXPECT_NEAR(xhi_havg.host_data(lev)[xhi_idx], hx, tol);
+        EXPECT_NEAR(ylo_havg.host_data(lev)[0], hy, tol);
+        EXPECT_NEAR(yhi_havg.host_data(lev)[yhi_idx], hy, tol);
+    }
+}
+
+TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel_boundary_cells)
+{
+    constexpr amrex::Real u0 = 4.0_rt;
+    constexpr amrex::Real v0 = 1.5_rt;
+    constexpr amrex::Real tol =
+        std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
+
+    populate_parameters();
+    initialize_mesh();
+
+    auto& repo = mesh().field_repo();
+    auto& velocity = repo.declare_field("velocity", 3, 1);
+    auto& vof = repo.declare_field("vof", 1, 1);
+
+    velocity.setVal(u0, 0, 1, 1);
+    velocity.setVal(v0, 1, 1, 1);
+    velocity.setVal(0.0_rt, 2, 1, 1);
+    vof.setVal(1.0_rt, 0, 1, 1);
+
+    kynema_sgf::Flather flather(sim());
+
+    kynema_sgf::MultiLevelVector xlo_uavg;
+    kynema_sgf::MultiLevelVector xlo_havg;
+    kynema_sgf::MultiLevelVector ylo_uavg;
+    kynema_sgf::MultiLevelVector ylo_havg;
+
+    xlo_uavg.resize(0, mesh().Geom());
+    xlo_havg.resize(0, mesh().Geom());
+    ylo_uavg.resize(1, mesh().Geom());
+    ylo_havg.resize(1, mesh().Geom());
+
+    const int nlevels = repo.num_active_levels();
+    EXPECT_EQ(nlevels, 2);
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        flather.accumulate_boundary(lev, 0, true, xlo_uavg, xlo_havg, true);
+        flather.accumulate_boundary(lev, 1, true, ylo_uavg, ylo_havg, true);
+
+        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);
+        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], v0, tol);
+
+        EXPECT_NEAR(xlo_havg.host_data(lev)[0], expected_h_x(mesh().Geom(lev)), tol);
+        EXPECT_NEAR(ylo_havg.host_data(lev)[0], expected_h_y(mesh().Geom(lev)), tol);
+    }
+}
+
+} // namespace kynema_sgf_tests

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -63,7 +63,7 @@ protected:
         std::stringstream ss;
         ss << "1 // Number of levels" << '\n';
         ss << "1 // Number of boxes at this level" << '\n';
-        ss << "3 3 3 5 5 5" << '\n';
+        ss << "0 0 2 8 8 6" << '\n';
 
         create_mesh_instance<RefineMesh>();
         std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -173,10 +173,10 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         const auto xhi_idx = xhi_uh.ncells(lev) - 1;
         const auto yhi_idx = yhi_uh.ncells(lev) - 1;
 
-        EXPECT_NEAR(xlo_uh.host_data(lev)[0], 0.0_rt, tol);
-        EXPECT_NEAR(xhi_uh.host_data(lev)[xhi_idx], u0 * m_wlev, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], 0.0_rt, tol);
-        EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], v0 * m_wlev, tol);
+        EXPECT_NEAR(xlo_uh.host_data(lev)[0], -u0 * m_wlev, tol);
+        EXPECT_NEAR(xhi_uh.host_data(lev)[xhi_idx], 0.0_rt, tol);
+        EXPECT_NEAR(ylo_uh.host_data(lev)[0], -v0 * m_wlev, tol);
+        EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], 0.0_rt, tol);
 
         const auto dz = (8.0_rt / (m_nx * (lev + 1)));
 

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -63,7 +63,7 @@ protected:
         std::stringstream ss;
         ss << "1 // Number of levels" << '\n';
         ss << "1 // Number of boxes at this level" << '\n';
-        ss << "0 0 2 8 8 6" << '\n';
+        ss << "0 0 2 4 6 6" << '\n';
 
         create_mesh_instance<RefineMesh>();
         std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -63,7 +63,7 @@ protected:
         std::stringstream ss;
         ss << "1 // Number of levels" << '\n';
         ss << "1 // Number of boxes at this level" << '\n';
-        ss << "0 0 2 4 6 6" << '\n';
+        ss << "0 0 2 4 8 6" << '\n';
 
         create_mesh_instance<RefineMesh>();
         std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(
@@ -77,7 +77,7 @@ protected:
     }
 
     const int m_nx{32};
-    const amrex::Real m_wlev{4.5_rt};
+    const amrex::Real m_wlev{4.07_rt};
 };
 
 TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
@@ -167,29 +167,22 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * m_wlev, tol);
         EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * m_wlev, tol);
 
+        const auto dz = (8.0_rt / (m_nx * (lev + 1)));
         // Liquid only
         flather.accumulate_boundary(
             lev, 0, 0, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
             true);
-        flather.accumulate_boundary(
-            lev, 1, 0, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
-            true);
 
-        const auto hliq = std::floor(m_wlev);
+        const auto hliq = std::floor(m_wlev / dz) * dz;
         EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hliq, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * hliq, tol);
 
         // Mix only
         flather.accumulate_boundary(
             lev, 0, 1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New,
             true);
-        flather.accumulate_boundary(
-            lev, 1, 1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New,
-            true);
 
-        const auto hmix = m_wlev - std::floor(m_wlev);
+        const auto hmix = m_wlev - hliq;
         EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * hmix, tol);
-        EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * hmix, tol);
     }
 }
 

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -92,12 +92,16 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 
     auto& repo = mesh().field_repo();
     auto& velocity = repo.declare_field("velocity", 3, 1);
-    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
+    const auto mac_fields =
+        repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
     auto& vof = repo.declare_field("vof", 1, 1);
 
     velocity.setVal(u0, 0, 1, 1);
     velocity.setVal(v0, 1, 1, 1);
     velocity.setVal(0.0_rt, 2, 1, 1);
+    mac_fields[0]->setVal(11.0_rt, 0, 1, 1);
+    mac_fields[1]->setVal(13.0_rt, 0, 1, 1);
+    mac_fields[2]->setVal(0.0_rt, 0, 1, 1);
     initialize_vof(vof, mesh().Geom(), m_wlev);
 
     kynema_sgf::Flather flather(sim());
@@ -111,14 +115,14 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
     kynema_sgf::MultiLevelVector yhi_uavg;
     kynema_sgf::MultiLevelVector yhi_havg;
 
-    xlo_uavg.resize(0, mesh().Geom());
-    xlo_havg.resize(0, mesh().Geom());
-    xhi_uavg.resize(0, mesh().Geom());
-    xhi_havg.resize(0, mesh().Geom());
-    ylo_uavg.resize(1, mesh().Geom());
-    ylo_havg.resize(1, mesh().Geom());
-    yhi_uavg.resize(1, mesh().Geom());
-    yhi_havg.resize(1, mesh().Geom());
+    xlo_uavg.resize(1, mesh().Geom());
+    xlo_havg.resize(1, mesh().Geom());
+    xhi_uavg.resize(1, mesh().Geom());
+    xhi_havg.resize(1, mesh().Geom());
+    ylo_uavg.resize(0, mesh().Geom());
+    ylo_havg.resize(0, mesh().Geom());
+    yhi_uavg.resize(0, mesh().Geom());
+    yhi_havg.resize(0, mesh().Geom());
 
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);
@@ -149,6 +153,16 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         EXPECT_NEAR(xhi_havg.host_data(lev)[xhi_idx], m_wlev, tol);
         EXPECT_NEAR(ylo_havg.host_data(lev)[0], m_wlev, tol);
         EXPECT_NEAR(yhi_havg.host_data(lev)[yhi_idx], m_wlev, tol);
+
+        flather.accumulate_boundary(
+            lev, 0, 0, true, xlo_uavg, xlo_havg, false,
+            kynema_sgf::FieldState::New, true);
+        flather.accumulate_boundary(
+            lev, 1, 0, true, ylo_uavg, ylo_havg, false,
+            kynema_sgf::FieldState::New, true);
+
+        EXPECT_NEAR(xlo_uavg.host_data(lev)[0], 11.0_rt, tol);
+        EXPECT_NEAR(ylo_uavg.host_data(lev)[0], 13.0_rt, tol);
     }
 }
 
@@ -184,14 +198,14 @@ TEST_F(
     kynema_sgf::MultiLevelVector yhi_uavg;
     kynema_sgf::MultiLevelVector yhi_havg;
 
-    xlo_uavg.resize(0, mesh().Geom());
-    xlo_havg.resize(0, mesh().Geom());
-    xhi_uavg.resize(0, mesh().Geom());
-    xhi_havg.resize(0, mesh().Geom());
-    ylo_uavg.resize(1, mesh().Geom());
-    ylo_havg.resize(1, mesh().Geom());
-    yhi_uavg.resize(1, mesh().Geom());
-    yhi_havg.resize(1, mesh().Geom());
+    xlo_uavg.resize(1, mesh().Geom());
+    xlo_havg.resize(1, mesh().Geom());
+    xhi_uavg.resize(1, mesh().Geom());
+    xhi_havg.resize(1, mesh().Geom());
+    ylo_uavg.resize(0, mesh().Geom());
+    ylo_havg.resize(0, mesh().Geom());
+    yhi_uavg.resize(0, mesh().Geom());
+    yhi_havg.resize(0, mesh().Geom());
 
     const int nlevels = repo.num_active_levels();
     EXPECT_EQ(nlevels, 2);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -131,12 +131,14 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, -1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New);
+            lev, 0, -1, true, xlo_uh, xlo_h, false,
+            kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
             lev, 0, -1, false, xhi_uh, xhi_h, false,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, -1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New);
+            lev, 1, -1, true, ylo_uh, ylo_h, false,
+            kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
             lev, 1, -1, false, yhi_uh, yhi_h, false,
             kynema_sgf::FieldState::New);
@@ -239,11 +241,13 @@ TEST_F(
         flather.accumulate_boundary(
             lev, 0, -1, true, xlo_uh, xlo_h, true, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 0, -1, false, xhi_uh, xhi_h, true, kynema_sgf::FieldState::New);
+            lev, 0, -1, false, xhi_uh, xhi_h, true,
+            kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
             lev, 1, -1, true, ylo_uh, ylo_h, true, kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, -1, false, yhi_uh, yhi_h, true, kynema_sgf::FieldState::New);
+            lev, 1, -1, false, yhi_uh, yhi_h, true,
+            kynema_sgf::FieldState::New);
 
         EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0, tol);
         EXPECT_NEAR(xhi_uh.host_data(lev)[0], u0, tol);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -125,16 +125,16 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, true, xlo_uavg, xlo_havg, false,
+            lev, 0, 0, true, xlo_uavg, xlo_havg, false,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 0, false, xhi_uavg, xhi_havg, false,
+            lev, 0, 0, false, xhi_uavg, xhi_havg, false,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, true, ylo_uavg, ylo_havg, false,
+            lev, 1, 0, true, ylo_uavg, ylo_havg, false,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, false, yhi_uavg, yhi_havg, false,
+            lev, 1, 0, false, yhi_uavg, yhi_havg, false,
             kynema_sgf::FieldState::New);
 
         const auto xhi_idx = xhi_uavg.ncells(lev) - 1;
@@ -198,16 +198,16 @@ TEST_F(
 
     for (int lev = 0; lev < nlevels; ++lev) {
         flather.accumulate_boundary(
-            lev, 0, true, xlo_uavg, xlo_havg, true,
+            lev, 0, 0, true, xlo_uavg, xlo_havg, true,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 0, false, xhi_uavg, xhi_havg, true,
+            lev, 0, 0, false, xhi_uavg, xhi_havg, true,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, true, ylo_uavg, ylo_havg, true,
+            lev, 1, 0, true, ylo_uavg, ylo_havg, true,
             kynema_sgf::FieldState::New);
         flather.accumulate_boundary(
-            lev, 1, false, yhi_uavg, yhi_havg, true,
+            lev, 1, 0, false, yhi_uavg, yhi_havg, true,
             kynema_sgf::FieldState::New);
 
         EXPECT_NEAR(xlo_uavg.host_data(lev)[0], u0, tol);

--- a/unit_tests/boundary_conditions/test_flather.cpp
+++ b/unit_tests/boundary_conditions/test_flather.cpp
@@ -178,7 +178,7 @@ TEST_F(FlatherBoundaryAverageTest, accumulate_boundary_multilevel)
         EXPECT_NEAR(ylo_uh.host_data(lev)[0], -v0 * m_wlev, tol);
         EXPECT_NEAR(yhi_uh.host_data(lev)[yhi_idx], 0.0_rt, tol);
 
-        const auto dz = (8.0_rt / (m_nx * (lev + 1)));
+        const auto dz = (8.0_rt / (m_nx << lev));
 
         // Liquid only
         flather.accumulate_boundary(
@@ -277,6 +277,120 @@ TEST_F(
 
         EXPECT_NEAR(xlo_uh.host_data(lev)[0], u0_mac * m_wlev, tol);
         EXPECT_NEAR(ylo_uh.host_data(lev)[0], v0_mac * m_wlev, tol);
+    }
+}
+
+class FlatherThreeLevelTest : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0_rt, 0.0_rt, 0.0_rt}};
+            amrex::Vector<amrex::Real> probhi{{8.0_rt, 8.0_rt, 8.0_rt}};
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+            amrex::Vector<int> periodic{{0, 0, 0}};
+            pp.addarr("is_periodic", periodic);
+        }
+        {
+            amrex::ParmParse pp("amr");
+            const amrex::Vector<int> ncell{{m_nx, m_nx, m_nx}};
+            pp.add("max_level", 2);
+            pp.add("max_grid_size", m_nx);
+            pp.add("blocking_factor", 2);
+            pp.addarr("n_cell", ncell);
+        }
+
+        // Two levels of refinement, nested so that the finest level is two
+        // refinement ratios removed from the coarsest
+        std::stringstream ss;
+        ss << "2 // Number of levels" << '\n';
+        ss << "1 // Number of boxes at this level" << '\n';
+        ss << "0 0 2 4 8 6" << '\n';
+        ss << "1 // Number of boxes at this level" << '\n';
+        ss << "0 0 3 2 8 5" << '\n';
+
+        create_mesh_instance<RefineMesh>();
+        std::unique_ptr<kynema_sgf::CartBoxRefinement> box_refine(
+            new kynema_sgf::CartBoxRefinement(sim()));
+        box_refine->read_inputs(mesh(), ss);
+
+        if (mesh<RefineMesh>() != nullptr) {
+            mesh<RefineMesh>()->refine_criteria_vec().push_back(
+                std::move(box_refine));
+        }
+    }
+
+    const int m_nx{32};
+    const amrex::Real m_wlev{4.07_rt};
+};
+
+TEST_F(FlatherThreeLevelTest, accumulate_boundary_index_translation)
+{
+    constexpr amrex::Real u0 = 2.0_rt;
+    constexpr amrex::Real v0 = 3.0_rt;
+    constexpr amrex::Real tol =
+        std::numeric_limits<amrex::Real>::epsilon() * 1.0e4_rt;
+
+    populate_parameters();
+    initialize_mesh();
+
+    auto& repo = mesh().field_repo();
+    auto& velocity = repo.declare_field("velocity", 3, 1);
+    repo.declare_face_normal_field({"u_mac", "v_mac", "w_mac"}, 1, 1, 1);
+    auto& vof = repo.declare_field("vof", 1, 1);
+
+    // Negative velocity makes xlo and ylo the outflow boundaries, so the
+    // interior sums are not clipped to zero
+    velocity.setVal(-u0, 0, 1, 1);
+    velocity.setVal(-v0, 1, 1, 1);
+    velocity.setVal(0.0_rt, 2, 1, 1);
+    initialize_vof(vof, mesh().Geom(), m_wlev);
+
+    kynema_sgf::Flather flather(sim());
+
+    const int nlevels = repo.num_active_levels();
+    ASSERT_EQ(nlevels, 3);
+    const int finest = nlevels - 1;
+
+    kynema_sgf::MultiLevelVector xlo_uh;
+    kynema_sgf::MultiLevelVector xlo_h;
+    kynema_sgf::MultiLevelVector ylo_uh;
+    kynema_sgf::MultiLevelVector ylo_h;
+
+    xlo_uh.resize(1, mesh().Geom());
+    xlo_h.resize(1, mesh().Geom());
+    ylo_uh.resize(0, mesh().Geom());
+    ylo_h.resize(0, mesh().Geom());
+
+    // Accumulating on the finest level draws contributions from levels that
+    // are one and two refinement ratios coarser
+    flather.accumulate_boundary(
+        finest, 0, -1, true, xlo_uh, xlo_h, false, kynema_sgf::FieldState::New);
+    flather.accumulate_boundary(
+        finest, 1, -1, true, ylo_uh, ylo_h, false, kynema_sgf::FieldState::New);
+
+    ASSERT_EQ(xlo_h.ncells(finest), m_nx * 4);
+    ASSERT_EQ(ylo_h.ncells(finest), m_nx * 4);
+
+    // Each column is covered by exactly one level, so a coarse index must map
+    // onto a contiguous range of fine indices with no gaps and no overlap.
+    // A gap leaves a column short and an overlap double counts it.
+    for (int n = 0; n < xlo_h.ncells(finest); ++n) {
+        EXPECT_NEAR(xlo_h.host_data(finest)[n], m_wlev, tol)
+            << "xlo liquid height, column " << n;
+        EXPECT_NEAR(xlo_uh.host_data(finest)[n], -u0 * m_wlev, tol)
+            << "xlo depth-integrated velocity, column " << n;
+    }
+    for (int n = 0; n < ylo_h.ncells(finest); ++n) {
+        EXPECT_NEAR(ylo_h.host_data(finest)[n], m_wlev, tol)
+            << "ylo liquid height, column " << n;
+        EXPECT_NEAR(ylo_uh.host_data(finest)[n], -v0 * m_wlev, tol)
+            << "ylo depth-integrated velocity, column " << n;
     }
 }
 


### PR DESCRIPTION
## Summary

For estuary flows, especially when using mesoscale data, the appropriate outflow condition should consider both the internal state and the external state, leading the free surface elevation to match the expected position at the outflow location. The Flather boundary condition is designed for that, using internal and external quantities and accelerating or decelerating flow according to the difference between the external and internal free surface locations.

However, it gets a lot more complicated when it is applied in 3D to a solver that has a 2-phase representation. The vertical profile needs to be scaled by depth-integrated quantities, and there ends up being a lot of edge cases to consider. Primarily, when it is not a good idea to use the internal profile for the outflow condition, the boundary needs to either use the known external profile or use a basic Neumann outflow condition. These should now be adequately implemented and documented.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [x] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

see below
