### PR TITLE
Update vof values within terrain

### DIFF
--- a/docs/sphinx/user/inputs_multiphase.rst
+++ b/docs/sphinx/user/inputs_multiphase.rst
@@ -52,8 +52,8 @@ terrain surface.
 
 The extrapolation is performed after the vof solve and before the density is computed from vof:
 - Blanked cells with at least one lateral neighbor (in x or y) that is not blanked take the average
-  vof of those internal unblanked neighbors. Values on the x or y domain boundary are not used as
-  sources.
+   vof of those unblanked neighbors. Valid cells on the x or y domain boundary may be used as
+   sources, but ghost cells outside the domain are excluded.
 - Blanked cells that have no non-blanked lateral neighbors take the average of the laterally
   neighboring blanked cells that have already been assigned a value. This is repeated in sweeps,
   so values propagate one layer deeper into the terrain per sweep until every reachable blanked

--- a/docs/sphinx/user/inputs_multiphase.rst
+++ b/docs/sphinx/user/inputs_multiphase.rst
@@ -36,3 +36,31 @@ This section is for the MultiPhase physics module, which is required for flows t
    source terms act in the presence of water. However, this parameter is not needed if the ``OceanWaves`` physics
    module is being used because; the ``water_level`` value is automatically populated in that case from the ``OceanWaves``
    setup parameters.
+
+Notes
+-----
+
+Terrain-blanked cells
+^^^^^^^^^^^^^^^^^^^^^
+
+When the ``terrain_blank`` int field is present (i.e., when a physics module such as
+:doc:`TerrainDrag <inputs_terraindrag>` or ``ChannelBuilder`` is active), the volume-of-fluid
+post-solve step extrapolates the vof field into the cells that are inside the terrain body
+(``terrain_blank = 1``). This keeps the interface within the solid from drifting away from the
+surrounding flow, which would otherwise lead to spurious density gradients and forcing near the
+terrain surface.
+
+The extrapolation is performed after the vof solve and before the density is computed from vof:
+
+- Blanked cells with at least one lateral neighbor (in x or y) that is not blanked take the average
+  vof of those unblanked neighbors.
+- Blanked cells that have no unblanked lateral neighbors take the average of the laterally
+  neighboring blanked cells that have already been assigned a value. This is repeated in sweeps,
+  so values propagate one layer deeper into the terrain per sweep until every reachable blanked
+  cell has been assigned.
+- Only lateral (x and y) neighbors are used, so each horizontal plane of cells is filled
+  independently of the planes above and below it.
+- Blanked cells that are not reachable from any unblanked cell keep their existing vof value.
+
+This step is a no-op when no ``terrain_blank`` field exists, and it does not modify the vof values
+of unblanked cells.

--- a/docs/sphinx/user/inputs_multiphase.rst
+++ b/docs/sphinx/user/inputs_multiphase.rst
@@ -53,14 +53,14 @@ terrain surface.
 The extrapolation is performed after the vof solve and before the density is computed from vof:
 
 - Blanked cells with at least one lateral neighbor (in x or y) that is not blanked take the average
-  vof of those unblanked neighbors.
-- Blanked cells that have no unblanked lateral neighbors take the average of the laterally
+  vof of those non-blanked neighbors.
+- Blanked cells that have no non-blanked lateral neighbors take the average of the laterally
   neighboring blanked cells that have already been assigned a value. This is repeated in sweeps,
   so values propagate one layer deeper into the terrain per sweep until every reachable blanked
   cell has been assigned.
 - Only lateral (x and y) neighbors are used, so each horizontal plane of cells is filled
   independently of the planes above and below it.
-- Blanked cells that are not reachable from any unblanked cell keep their existing vof value.
+- Blanked cells that are not reachable from any non-blanked cell keep their existing vof value.
 
 This step is a no-op when no ``terrain_blank`` field exists, and it does not modify the vof values
-of unblanked cells.
+of non-blanked cells.

--- a/docs/sphinx/user/inputs_multiphase.rst
+++ b/docs/sphinx/user/inputs_multiphase.rst
@@ -51,9 +51,9 @@ surrounding flow, which would otherwise lead to spurious density gradients and f
 terrain surface.
 
 The extrapolation is performed after the vof solve and before the density is computed from vof:
-
 - Blanked cells with at least one lateral neighbor (in x or y) that is not blanked take the average
-  vof of those non-blanked neighbors.
+  vof of those internal unblanked neighbors. Values on the x or y domain boundary are not used as
+  sources.
 - Blanked cells that have no non-blanked lateral neighbors take the average of the laterally
   neighboring blanked cells that have already been assigned a value. This is repeated in sweeps,
   so values propagate one layer deeper into the terrain per sweep until every reachable blanked

--- a/docs/sphinx/user/inputs_terraindrag.rst
+++ b/docs/sphinx/user/inputs_terraindrag.rst
@@ -128,3 +128,5 @@ Notes
   ``terrain_height`` from wave fields and sets a uniform low roughness
   (``terrainz0 = 1.0e-4``).
 - In ocean-wave mode, terrain-file and roughness-file parameters are not used.
+- When the ``MultiPhase`` physics module is active, the vof post-solve step extrapolates vof
+  laterally into the cells with ``terrain_blank = 1``; see :doc:`inputs_multiphase`.

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -95,11 +95,6 @@ struct PostSolveOp<VOF>
             const auto periodicity = m_sim.mesh().Geom(lev).periodicity();
             const auto ngrow = buf.nGrowVect();
             const auto domain = m_sim.mesh().Geom(lev).Domain();
-            const auto source_domain = amrex::Box(
-                {domain.smallEnd(0) + 1, domain.smallEnd(1) + 1,
-                 domain.smallEnd(2)},
-                {domain.bigEnd(0) - 1, domain.bigEnd(1) - 1,
-                 domain.bigEnd(2)});
             buf.setVal(-1.0_rt);
 
             const auto blank_arrs = blanking(lev).const_arrays();
@@ -109,8 +104,7 @@ struct PostSolveOp<VOF>
                 amrex::ParallelFor(
                     buf, amrex::IntVect(0),
                     [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
-                        if (source_domain.contains(i, j, k) &&
-                            blank_arrs[nbx](i, j, k) == 0) {
+                        if (blank_arrs[nbx](i, j, k) == 0) {
                             buf_arrs[nbx](i, j, k, 0) = vof_arrs[nbx](i, j, k);
                         }
                     });
@@ -139,7 +133,7 @@ struct PostSolveOp<VOF>
                             for (int nj = -1; nj <= 1; ++nj) {
                                 const int ii = i + ni;
                                 const int jj = j + nj;
-                                if (!source_domain.contains(ii, jj, k)) {
+                                if (!domain.contains(ii, jj, k)) {
                                     continue;
                                 }
                                 const amrex::Real nval = bf(ii, jj, k, src);

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -143,7 +143,7 @@ struct PostSolveOp<VOF>
                                 }
                             }
                         }
-                        if (cnt > 0) {
+                        if (cnt > 1) {
                             bf(i, j, k, dst) =
                                 sum / static_cast<amrex::Real>(cnt);
                             return {1};

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -85,6 +85,8 @@ struct PostSolveOp<VOF>
         auto& vof = m_fields.field;
         const int nlevels = repo.num_active_levels();
 
+        constexpr amrex::Real vof_tiny = 1.0e-8_rt;
+
         // Two components used to ping-pong between sweeps so that values
         // assigned during a sweep are not used as sources within that sweep.
         // A negative value flags a cell that has not been assigned yet.
@@ -146,6 +148,12 @@ struct PostSolveOp<VOF>
                         if (cnt > 1) {
                             bf(i, j, k, dst) =
                                 sum / static_cast<amrex::Real>(cnt);
+                            // Snap to VOF bounds
+                            if (bf(i, j, k, dst) < vof_tiny) {
+                                bf(i, j, k, dst) = 0.0_rt;
+                            } else if (bf(i, j, k, dst) > 1.0_rt - vof_tiny) {
+                                bf(i, j, k, dst) = 1.0_rt;
+                            }
                             return {1};
                         }
                         bf(i, j, k, dst) = -1.0_rt;

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -3,6 +3,7 @@
 
 #include "src/equation_systems/vof/vof.H"
 #include "src/physics/multiphase/MultiPhase.H"
+#include "AMReX_MultiFabUtil.H"
 #include "AMReX_ParReduce.H"
 
 namespace kynema_sgf::pde {
@@ -97,16 +98,33 @@ struct PostSolveOp<VOF>
             const auto periodicity = m_sim.mesh().Geom(lev).periodicity();
             const auto ngrow = buf.nGrowVect();
             const auto domain = m_sim.mesh().Geom(lev).Domain();
+            amrex::iMultiFab level_mask;
+            if (lev < nlevels - 1) {
+                level_mask = amrex::makeFineMask(
+                    m_sim.mesh().boxArray(lev),
+                    m_sim.mesh().DistributionMap(lev),
+                    m_sim.mesh().boxArray(lev + 1),
+                    m_sim.mesh().refRatio(lev), 1, 0);
+            } else {
+                level_mask.define(
+                    m_sim.mesh().boxArray(lev),
+                    m_sim.mesh().DistributionMap(lev), 1, 0,
+                    amrex::MFInfo());
+                level_mask.setVal(1);
+            }
             buf.setVal(-1.0_rt);
 
             const auto blank_arrs = blanking(lev).const_arrays();
+            const auto mask_arrs = level_mask.const_arrays();
             {
                 const auto buf_arrs = buf.arrays();
                 const auto vof_arrs = vof(lev).const_arrays();
                 amrex::ParallelFor(
                     buf, amrex::IntVect(0),
                     [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
-                        if (blank_arrs[nbx](i, j, k) == 0) {
+                        if (mask_arrs[nbx](i, j, k) == 1 &&
+                            domain.contains(i, j, k) &&
+                            blank_arrs[nbx](i, j, k) == 0) {
                             buf_arrs[nbx](i, j, k, 0) = vof_arrs[nbx](i, j, k);
                         }
                     });
@@ -174,7 +192,9 @@ struct PostSolveOp<VOF>
                 vof(lev), amrex::IntVect(0),
                 [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
                     const amrex::Real val = buf_arrs[nbx](i, j, k, src);
-                    if (blank_arrs[nbx](i, j, k) == 1 && val >= 0.0_rt) {
+                    if (mask_arrs[nbx](i, j, k) == 1 &&
+                        blank_arrs[nbx](i, j, k) == 1 &&
+                        val >= 0.0_rt) {
                         vof_arrs[nbx](i, j, k) = val;
                     }
                 });

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -128,12 +128,12 @@ struct PostSolveOp<VOF>
                         }
                         amrex::Real sum = 0.0_rt;
                         int cnt = 0;
-                        for (int dir = 0; dir < 2; ++dir) {
-                            for (int sgn = -1; sgn <= 1; sgn += 2) {
-                                const int ii = i + ((dir == 0) ? sgn : 0);
-                                const int jj = j + ((dir == 1) ? sgn : 0);
+                        for (int ni = -1; ni <= 1; ++ni) {
+                            for (int nj = -1; nj <= 1; ++nj) {
+                                const int ii = i + ni;
+                                const int jj = j + nj;
                                 const amrex::Real nval = bf(ii, jj, k, src);
-                                if (nval >= 0.0_rt) {
+                                if (nval >= 0.0_rt && !(ni == 0 && nj == 0)) {
                                     sum += nval;
                                     ++cnt;
                                 }

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -3,6 +3,7 @@
 
 #include "src/equation_systems/vof/vof.H"
 #include "src/physics/multiphase/MultiPhase.H"
+#include "AMReX_ParReduce.H"
 
 namespace kynema_sgf::pde {
 
@@ -70,9 +71,115 @@ struct PostSolveOp<VOF>
     PostSolveOp(CFDSim& sim, PDEFields& fields) : m_sim(sim), m_fields(fields)
     {}
 
+    /** Extrapolate vof laterally into terrain-blanked cells
+     *
+     *  Blanked cells that border unblanked cells in x or y take the average vof
+     *  of those unblanked neighbors. Blanked cells surrounded by blanked cells
+     *  take the average of their laterally neighboring cells that have already
+     *  been assigned, propagating the values inward one layer per sweep.
+     */
+    void extrapolate_vof_into_terrain()
+    {
+        auto& repo = m_sim.repo();
+        const auto& blanking = repo.get_int_field("terrain_blank");
+        auto& vof = m_fields.field;
+        const int nlevels = repo.num_active_levels();
+
+        // Two components used to ping-pong between sweeps so that values
+        // assigned during a sweep are not used as sources within that sweep.
+        // A negative value flags a cell that has not been assigned yet.
+        auto scratch = repo.create_scratch_field(2, 1);
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+            auto& buf = (*scratch)(lev);
+            const auto periodicity = m_sim.mesh().Geom(lev).periodicity();
+            const auto ngrow = buf.nGrowVect();
+            buf.setVal(-1.0_rt);
+
+            const auto blank_arrs = blanking(lev).const_arrays();
+            {
+                const auto buf_arrs = buf.arrays();
+                const auto vof_arrs = vof(lev).const_arrays();
+                amrex::ParallelFor(
+                    buf, amrex::IntVect(0),
+                    [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                        if (blank_arrs[nbx](i, j, k) == 0) {
+                            buf_arrs[nbx](i, j, k, 0) = vof_arrs[nbx](i, j, k);
+                        }
+                    });
+                amrex::Gpu::streamSynchronize();
+            }
+            buf.FillBoundary(0, 1, ngrow, periodicity);
+
+            int src = 0;
+            while (true) {
+                const int dst = 1 - src;
+                const auto buf_arrs = buf.arrays();
+                auto nfilled = amrex::ParReduce(
+                    amrex::TypeList<amrex::ReduceOpSum>{},
+                    amrex::TypeList<amrex::Long>{}, buf, amrex::IntVect(0),
+                    [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k)
+                        -> amrex::GpuTuple<amrex::Long> {
+                        const auto& bf = buf_arrs[nbx];
+                        const amrex::Real cur = bf(i, j, k, src);
+                        if (cur >= 0.0_rt) {
+                            bf(i, j, k, dst) = cur;
+                            return {0};
+                        }
+                        amrex::Real sum = 0.0_rt;
+                        int cnt = 0;
+                        for (int dir = 0; dir < 2; ++dir) {
+                            for (int sgn = -1; sgn <= 1; sgn += 2) {
+                                const int ii = i + ((dir == 0) ? sgn : 0);
+                                const int jj = j + ((dir == 1) ? sgn : 0);
+                                const amrex::Real nval = bf(ii, jj, k, src);
+                                if (nval >= 0.0_rt) {
+                                    sum += nval;
+                                    ++cnt;
+                                }
+                            }
+                        }
+                        if (cnt > 0) {
+                            bf(i, j, k, dst) =
+                                sum / static_cast<amrex::Real>(cnt);
+                            return {1};
+                        }
+                        bf(i, j, k, dst) = -1.0_rt;
+                        return {0};
+                    });
+                amrex::ParallelDescriptor::ReduceLongSum(nfilled);
+                buf.FillBoundary(dst, 1, ngrow, periodicity);
+                src = dst;
+                // No cell was assigned during this sweep; nothing left to do
+                if (nfilled == 0) {
+                    break;
+                }
+            }
+
+            const auto buf_arrs = buf.const_arrays();
+            const auto vof_arrs = vof(lev).arrays();
+            amrex::ParallelFor(
+                vof(lev), amrex::IntVect(0),
+                [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                    const amrex::Real val = buf_arrs[nbx](i, j, k, src);
+                    if (blank_arrs[nbx](i, j, k) == 1 && val >= 0.0_rt) {
+                        vof_arrs[nbx](i, j, k) = val;
+                    }
+                });
+            amrex::Gpu::streamSynchronize();
+        }
+
+        vof.fillpatch(m_sim.time().new_time());
+    }
+
     void operator()(const amrex::Real /*unused*/)
     {
         m_fields.field.fillpatch(m_sim.time().new_time());
+
+        if (m_sim.repo().int_field_exists("terrain_blank")) {
+            extrapolate_vof_into_terrain();
+        }
+
         auto& multiphase = m_sim.physics_manager().get<MultiPhase>();
         multiphase.set_density_via_vof();
 

--- a/src/equation_systems/vof/vof_ops.H
+++ b/src/equation_systems/vof/vof_ops.H
@@ -94,6 +94,12 @@ struct PostSolveOp<VOF>
             auto& buf = (*scratch)(lev);
             const auto periodicity = m_sim.mesh().Geom(lev).periodicity();
             const auto ngrow = buf.nGrowVect();
+            const auto domain = m_sim.mesh().Geom(lev).Domain();
+            const auto source_domain = amrex::Box(
+                {domain.smallEnd(0) + 1, domain.smallEnd(1) + 1,
+                 domain.smallEnd(2)},
+                {domain.bigEnd(0) - 1, domain.bigEnd(1) - 1,
+                 domain.bigEnd(2)});
             buf.setVal(-1.0_rt);
 
             const auto blank_arrs = blanking(lev).const_arrays();
@@ -103,7 +109,8 @@ struct PostSolveOp<VOF>
                 amrex::ParallelFor(
                     buf, amrex::IntVect(0),
                     [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
-                        if (blank_arrs[nbx](i, j, k) == 0) {
+                        if (source_domain.contains(i, j, k) &&
+                            blank_arrs[nbx](i, j, k) == 0) {
                             buf_arrs[nbx](i, j, k, 0) = vof_arrs[nbx](i, j, k);
                         }
                     });
@@ -132,6 +139,9 @@ struct PostSolveOp<VOF>
                             for (int nj = -1; nj <= 1; ++nj) {
                                 const int ii = i + ni;
                                 const int jj = j + nj;
+                                if (!source_domain.contains(ii, jj, k)) {
+                                    continue;
+                                }
                                 const amrex::Real nval = bf(ii, jj, k, src);
                                 if (nval >= 0.0_rt && !(ni == 0 && nj == 0)) {
                                     sum += nval;

--- a/unit_tests/multiphase/CMakeLists.txt
+++ b/unit_tests/multiphase/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(
   test_mflux_schemes.cpp
   test_reference_fields.cpp
   test_vof_overset_ops.cpp
+  test_vof_terrain_fill.cpp
   )

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -151,7 +151,7 @@ void get_error_boundary_source_case(
         const auto& vof_arr = vof(lev).const_array(mfi);
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
             const amrex::Real expected =
-                ((i == 1) && (j == 4)) ? 0.2_rt
+                ((i == 1) && (j == 4)) ? 0.5_rt
                                        : (((i == 0) || (i == 7)) ? 1.0_rt
                                                                   : 0.2_rt);
             err_arr(i, j, k) =
@@ -283,7 +283,7 @@ TEST_F(VOFTerrainFillTest, lateral_diagonal_average)
     EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
 }
 
-TEST_F(VOFTerrainFillTest, excludes_domain_boundary_sources)
+TEST_F(VOFTerrainFillTest, includes_valid_domain_boundary_sources)
 {
     setup_sim();
 

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -11,6 +11,75 @@ using namespace amrex::literals;
 namespace kynema_sgf_tests {
 namespace {
 
+//! 4 x 4 blanked column block within a uniform vof field
+void init_blanked_block(
+    kynema_sgf::Field& vof,
+    kynema_sgf::IntField& blanking,
+    const amrex::Real vof_fluid)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool in_terrain =
+                (i >= 2) && (i <= 5) && (j >= 2) && (j <= 5);
+            blank_arr(i, j, k) = in_terrain ? 1 : 0;
+            vof_arr(i, j, k) = in_terrain ? 0.0_rt : vof_fluid;
+        });
+    });
+    vof.fillpatch(0.0_rt);
+}
+
+//! Single blanked plane at i = 4, with a vof field that varies in x and z
+void init_blanked_plane(kynema_sgf::Field& vof, kynema_sgf::IntField& blanking)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool in_terrain = (i == 4);
+            blank_arr(i, j, k) = in_terrain ? 1 : 0;
+            vof_arr(i, j, k) =
+                in_terrain ? 0.0_rt : (0.1_rt * i) + (0.01_rt * k);
+        });
+    });
+    vof.fillpatch(0.0_rt);
+}
+
+void get_error_uniform(
+    kynema_sgf::ScratchField& err_fld,
+    kynema_sgf::Field& vof,
+    const amrex::Real vof_fluid)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = err_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            err_arr(i, j, k) = amrex::Math::abs(vof_arr(i, j, k) - vof_fluid);
+        });
+    });
+}
+
+void get_error_blanked_plane(
+    kynema_sgf::ScratchField& err_fld, kynema_sgf::Field& vof)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = err_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            // Average of the i = 3 and i = 5 neighbors within the same plane
+            const amrex::Real expected = (i == 4)
+                                             ? (0.4_rt + (0.01_rt * k))
+                                             : ((0.1_rt * i) + (0.01_rt * k));
+            err_arr(i, j, k) = amrex::Math::abs(vof_arr(i, j, k) - expected);
+        });
+    });
+}
+
 class VOFTerrainFillTest : public MeshTest
 {
 protected:
@@ -76,20 +145,9 @@ TEST_F(VOFTerrainFillTest, uniform_vof_block)
     auto& blanking = repo.get_int_field("terrain_blank");
     constexpr amrex::Real vof_fluid = 0.7_rt;
 
-    // 4 x 4 blanked column block: the innermost cells have no unblanked
-    // lateral neighbors and are only reached by successive sweeps
-    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
-        const auto& bx = mfi.validbox();
-        const auto& vof_arr = vof(lev).array(mfi);
-        const auto& blank_arr = blanking(lev).array(mfi);
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            const bool in_terrain =
-                (i >= 2) && (i <= 5) && (j >= 2) && (j <= 5);
-            blank_arr(i, j, k) = in_terrain ? 1 : 0;
-            vof_arr(i, j, k) = in_terrain ? 0.0_rt : vof_fluid;
-        });
-    });
-    vof.fillpatch(0.0_rt);
+    // The innermost blanked cells have no unblanked lateral neighbors and are
+    // only reached by successive sweeps
+    init_blanked_block(vof, blanking, vof_fluid);
 
     kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
         sim(), vof_fields());
@@ -97,14 +155,7 @@ TEST_F(VOFTerrainFillTest, uniform_vof_block)
 
     auto error_ptr = repo.create_scratch_field(1, 0);
     auto& error_fld = *error_ptr;
-    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
-        const auto& bx = mfi.validbox();
-        const auto& err_arr = error_fld(lev).array(mfi);
-        const auto& vof_arr = vof(lev).const_array(mfi);
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            err_arr(i, j, k) = std::abs(vof_arr(i, j, k) - vof_fluid);
-        });
-    });
+    get_error_uniform(error_fld, vof, vof_fluid);
 
     EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
 }
@@ -118,20 +169,7 @@ TEST_F(VOFTerrainFillTest, lateral_average_only)
     auto& vof = repo.get_field("vof");
     auto& blanking = repo.get_int_field("terrain_blank");
 
-    // Single blanked plane at i = 4 spanning all j and k, with a vof field
-    // that varies in both x and z
-    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
-        const auto& bx = mfi.validbox();
-        const auto& vof_arr = vof(lev).array(mfi);
-        const auto& blank_arr = blanking(lev).array(mfi);
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            const bool in_terrain = (i == 4);
-            blank_arr(i, j, k) = in_terrain ? 1 : 0;
-            vof_arr(i, j, k) =
-                in_terrain ? 0.0_rt : (0.1_rt * i) + (0.01_rt * k);
-        });
-    });
-    vof.fillpatch(0.0_rt);
+    init_blanked_plane(vof, blanking);
 
     kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
         sim(), vof_fields());
@@ -139,18 +177,7 @@ TEST_F(VOFTerrainFillTest, lateral_average_only)
 
     auto error_ptr = repo.create_scratch_field(1, 0);
     auto& error_fld = *error_ptr;
-    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
-        const auto& bx = mfi.validbox();
-        const auto& err_arr = error_fld(lev).array(mfi);
-        const auto& vof_arr = vof(lev).const_array(mfi);
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            // Average of the i = 3 and i = 5 neighbors within the same plane
-            const amrex::Real expected = (i == 4)
-                                             ? (0.4_rt + (0.01_rt * k))
-                                             : ((0.1_rt * i) + (0.01_rt * k));
-            err_arr(i, j, k) = std::abs(vof_arr(i, j, k) - expected);
-        });
-    });
+    get_error_blanked_plane(error_fld, vof);
 
     EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
 }

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -83,8 +83,8 @@ TEST_F(VOFTerrainFillTest, uniform_vof_block)
         const auto& vof_arr = vof(lev).array(mfi);
         const auto& blank_arr = blanking(lev).array(mfi);
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            const bool in_terrain = (i >= 2) && (i <= 5) && (j >= 2) &&
-                                    (j <= 5);
+            const bool in_terrain =
+                (i >= 2) && (i <= 5) && (j >= 2) && (j <= 5);
             blank_arr(i, j, k) = in_terrain ? 1 : 0;
             vof_arr(i, j, k) = in_terrain ? 0.0_rt : vof_fluid;
         });
@@ -145,9 +145,9 @@ TEST_F(VOFTerrainFillTest, lateral_average_only)
         const auto& vof_arr = vof(lev).const_array(mfi);
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
             // Average of the i = 3 and i = 5 neighbors within the same plane
-            const amrex::Real expected =
-                (i == 4) ? (0.4_rt + (0.01_rt * k))
-                         : ((0.1_rt * i) + (0.01_rt * k));
+            const amrex::Real expected = (i == 4)
+                                             ? (0.4_rt + (0.01_rt * k))
+                                             : ((0.1_rt * i) + (0.01_rt * k));
             err_arr(i, j, k) = std::abs(vof_arr(i, j, k) - expected);
         });
     });

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -70,6 +70,23 @@ void init_diagonal_case(
     vof.fillpatch(0.0_rt);
 }
 
+void init_boundary_source_case(
+    kynema_sgf::Field& vof, kynema_sgf::IntField& blanking)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool is_target = (i == 1) && (j == 4);
+            const bool is_boundary = (i == 0) || (i == 7);
+            blank_arr(i, j, k) = is_target ? 1 : 0;
+            vof_arr(i, j, k) = is_boundary ? 1.0_rt : 0.2_rt;
+        });
+    });
+    vof.fillpatch(0.0_rt);
+}
+
 void get_error_uniform(
     kynema_sgf::ScratchField& err_fld,
     kynema_sgf::Field& vof,
@@ -121,6 +138,24 @@ void get_error_diagonal_case(
                 (is_center || is_diagonal)
                     ? amrex::Math::abs(vof_arr(i, j, k) - expected)
                     : 0.0_rt;
+        });
+    });
+}
+
+void get_error_boundary_source_case(
+    kynema_sgf::ScratchField& err_fld, kynema_sgf::Field& vof)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = err_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const amrex::Real expected =
+                ((i == 1) && (j == 4)) ? 0.2_rt
+                                       : (((i == 0) || (i == 7)) ? 1.0_rt
+                                                                  : 0.2_rt);
+            err_arr(i, j, k) =
+                amrex::Math::abs(vof_arr(i, j, k) - expected);
         });
     });
 }
@@ -244,6 +279,27 @@ TEST_F(VOFTerrainFillTest, lateral_diagonal_average)
     auto error_ptr = repo.create_scratch_field(1, 0);
     auto& error_fld = *error_ptr;
     get_error_diagonal_case(error_fld, vof);
+
+    EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
+}
+
+TEST_F(VOFTerrainFillTest, excludes_domain_boundary_sources)
+{
+    setup_sim();
+
+    auto& repo = sim().repo();
+    auto& vof = repo.get_field("vof");
+    auto& blanking = repo.get_int_field("terrain_blank");
+
+    init_boundary_source_case(vof, blanking);
+
+    kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
+        sim(), vof_fields());
+    post_solve.extrapolate_vof_into_terrain();
+
+    auto error_ptr = repo.create_scratch_field(1, 0);
+    auto& error_fld = *error_ptr;
+    get_error_boundary_source_case(error_fld, vof);
 
     EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
 }

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -48,6 +48,28 @@ void init_blanked_plane(kynema_sgf::Field& vof, kynema_sgf::IntField& blanking)
     vof.fillpatch(0.0_rt);
 }
 
+void init_diagonal_case(
+    kynema_sgf::Field& vof, kynema_sgf::IntField& blanking)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool is_center = (i == 4) && (j == 4);
+            const bool is_cardinal =
+                ((i == 4) && (j == 3 || j == 5)) ||
+                ((j == 4) && (i == 3 || i == 5));
+            const bool is_diagonal =
+                (i == 3 || i == 5) && (j == 3 || j == 5);
+            blank_arr(i, j, k) = (is_center || is_cardinal) ? 1 : 0;
+            vof_arr(i, j, k) = is_diagonal ? (0.1_rt * i + 0.01_rt * j)
+                                          : 0.0_rt;
+        });
+    });
+    vof.fillpatch(0.0_rt);
+}
+
 void get_error_uniform(
     kynema_sgf::ScratchField& err_fld,
     kynema_sgf::Field& vof,
@@ -76,6 +98,29 @@ void get_error_blanked_plane(
                                              ? (0.4_rt + (0.01_rt * k))
                                              : ((0.1_rt * i) + (0.01_rt * k));
             err_arr(i, j, k) = amrex::Math::abs(vof_arr(i, j, k) - expected);
+        });
+    });
+}
+
+void get_error_diagonal_case(
+    kynema_sgf::ScratchField& err_fld, kynema_sgf::Field& vof)
+{
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = err_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool is_center = (i == 4) && (j == 4);
+            const bool is_diagonal =
+                (i == 3 || i == 5) && (j == 3 || j == 5);
+            const amrex::Real expected =
+                is_center   ? (0.1_rt * 4.0_rt + 0.01_rt * 4.0_rt)
+                : is_diagonal ? (0.1_rt * i + 0.01_rt * j)
+                              : 0.0_rt;
+            err_arr(i, j, k) =
+                (is_center || is_diagonal)
+                    ? amrex::Math::abs(vof_arr(i, j, k) - expected)
+                    : 0.0_rt;
         });
     });
 }
@@ -178,6 +223,27 @@ TEST_F(VOFTerrainFillTest, lateral_average_only)
     auto error_ptr = repo.create_scratch_field(1, 0);
     auto& error_fld = *error_ptr;
     get_error_blanked_plane(error_fld, vof);
+
+    EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
+}
+
+TEST_F(VOFTerrainFillTest, lateral_diagonal_average)
+{
+    setup_sim();
+
+    auto& repo = sim().repo();
+    auto& vof = repo.get_field("vof");
+    auto& blanking = repo.get_int_field("terrain_blank");
+
+    init_diagonal_case(vof, blanking);
+
+    kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
+        sim(), vof_fields());
+    post_solve.extrapolate_vof_into_terrain();
+
+    auto error_ptr = repo.create_scratch_field(1, 0);
+    auto& error_fld = *error_ptr;
+    get_error_diagonal_case(error_fld, vof);
 
     EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
 }

--- a/unit_tests/multiphase/test_vof_terrain_fill.cpp
+++ b/unit_tests/multiphase/test_vof_terrain_fill.cpp
@@ -1,0 +1,179 @@
+#include "ks_test_utils/MeshTest.H"
+#include "ks_test_utils/iter_tools.H"
+#include "ks_test_utils/test_utils.H"
+#include "src/equation_systems/SchemeTraits.H"
+#include "src/equation_systems/vof/vof.H"
+#include "src/equation_systems/vof/vof_ops.H"
+#include "AMReX_REAL.H"
+
+using namespace amrex::literals;
+
+namespace kynema_sgf_tests {
+namespace {
+
+class VOFTerrainFillTest : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            // Multiple boxes to exercise the ghost exchange between sweeps
+            amrex::ParmParse pp("amr");
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", 4);
+        }
+        {
+            amrex::ParmParse pp("MultiPhase");
+            pp.add("density_fluid1", 1000.0_rt);
+            pp.add("density_fluid2", 1.0_rt);
+        }
+        {
+            amrex::ParmParse pp("incflo");
+            amrex::Vector<std::string> physics{"MultiPhase"};
+            pp.addarr("physics", physics);
+            pp.add("use_godunov", 1);
+        }
+    }
+
+    void setup_sim()
+    {
+        initialize_mesh();
+
+        auto& pde_mgr = sim().pde_manager();
+        auto& mom_eqn = pde_mgr.register_icns();
+        mom_eqn.initialize();
+
+        // Registers the VOF equation and the associated fields
+        sim().init_physics();
+
+        sim().repo().declare_int_field("terrain_blank", 1, 1, 1);
+    }
+
+    kynema_sgf::pde::PDEFields& vof_fields()
+    {
+        return sim()
+            .pde_manager()(
+                kynema_sgf::pde::VOF::pde_name() + "-" +
+                kynema_sgf::fvm::Godunov::scheme_name())
+            .fields();
+    }
+};
+
+constexpr amrex::Real tol =
+    std::numeric_limits<amrex::Real>::epsilon() * 1.0e2_rt;
+
+} // namespace
+
+//! Blanked cells several layers deep must all recover a uniform vof value
+TEST_F(VOFTerrainFillTest, uniform_vof_block)
+{
+    setup_sim();
+
+    auto& repo = sim().repo();
+    auto& vof = repo.get_field("vof");
+    auto& blanking = repo.get_int_field("terrain_blank");
+    constexpr amrex::Real vof_fluid = 0.7_rt;
+
+    // 4 x 4 blanked column block: the innermost cells have no unblanked
+    // lateral neighbors and are only reached by successive sweeps
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool in_terrain = (i >= 2) && (i <= 5) && (j >= 2) &&
+                                    (j <= 5);
+            blank_arr(i, j, k) = in_terrain ? 1 : 0;
+            vof_arr(i, j, k) = in_terrain ? 0.0_rt : vof_fluid;
+        });
+    });
+    vof.fillpatch(0.0_rt);
+
+    kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
+        sim(), vof_fields());
+    post_solve.extrapolate_vof_into_terrain();
+
+    auto error_ptr = repo.create_scratch_field(1, 0);
+    auto& error_fld = *error_ptr;
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = error_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            err_arr(i, j, k) = std::abs(vof_arr(i, j, k) - vof_fluid);
+        });
+    });
+
+    EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
+}
+
+//! Blanked cells average their lateral neighbors only, not their z neighbors
+TEST_F(VOFTerrainFillTest, lateral_average_only)
+{
+    setup_sim();
+
+    auto& repo = sim().repo();
+    auto& vof = repo.get_field("vof");
+    auto& blanking = repo.get_int_field("terrain_blank");
+
+    // Single blanked plane at i = 4 spanning all j and k, with a vof field
+    // that varies in both x and z
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& vof_arr = vof(lev).array(mfi);
+        const auto& blank_arr = blanking(lev).array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            const bool in_terrain = (i == 4);
+            blank_arr(i, j, k) = in_terrain ? 1 : 0;
+            vof_arr(i, j, k) =
+                in_terrain ? 0.0_rt : (0.1_rt * i) + (0.01_rt * k);
+        });
+    });
+    vof.fillpatch(0.0_rt);
+
+    kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
+        sim(), vof_fields());
+    post_solve.extrapolate_vof_into_terrain();
+
+    auto error_ptr = repo.create_scratch_field(1, 0);
+    auto& error_fld = *error_ptr;
+    run_algorithm(vof, [&](const int lev, const amrex::MFIter& mfi) {
+        const auto& bx = mfi.validbox();
+        const auto& err_arr = error_fld(lev).array(mfi);
+        const auto& vof_arr = vof(lev).const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            // Average of the i = 3 and i = 5 neighbors within the same plane
+            const amrex::Real expected =
+                (i == 4) ? (0.4_rt + (0.01_rt * k))
+                         : ((0.1_rt * i) + (0.01_rt * k));
+            err_arr(i, j, k) = std::abs(vof_arr(i, j, k) - expected);
+        });
+    });
+
+    EXPECT_NEAR(error_fld(0).max(0), 0.0_rt, tol);
+}
+
+//! Cells that cannot be reached from any unblanked cell are left alone
+TEST_F(VOFTerrainFillTest, fully_blanked_domain)
+{
+    setup_sim();
+
+    auto& repo = sim().repo();
+    auto& vof = repo.get_field("vof");
+    auto& blanking = repo.get_int_field("terrain_blank");
+    constexpr amrex::Real vof_init = 0.25_rt;
+
+    blanking.setVal(1);
+    vof.setVal(vof_init);
+
+    kynema_sgf::pde::PostSolveOp<kynema_sgf::pde::VOF> post_solve(
+        sim(), vof_fields());
+    post_solve.extrapolate_vof_into_terrain();
+
+    EXPECT_NEAR(vof(0).max(0), vof_init, tol);
+    EXPECT_NEAR(vof(0).min(0), vof_init, tol);
+}
+
+} // namespace kynema_sgf_tests


### PR DESCRIPTION
## Summary

IBFM is not a true wall implementation, and the strong inertia or weight of water pushes vof into the wall cells, which affects the interface position for IBFM cases with waves or sea level rise. To address this, this PR fills in the vof values within the terrain to match the values in the non-terrain cells. It is effectively a Neumann condition for vof in the terrain cells. Also, because the vof determines density, this helps push back against hydrostatic forces pushing fluid into non-fluid cells.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Will affect regression tests
